### PR TITLE
Fix compilation error

### DIFF
--- a/docs/languages/en/modules/zend.feed.pubsubhubbub.rst
+++ b/docs/languages/en/modules/zend.feed.pubsubhubbub.rst
@@ -398,7 +398,7 @@ Actually adding the route which would map the path-appended key to a parameter f
 be accomplished using a Route configuration such as the *INI* formatted example below for use with
 ``Zend_Application`` bootstrapping.
 
-.. code-block:: dosini
+.. code-block:: ini
    :linenos:
 
    ; Callback Route to enable appending a PuSH Subscription's lookup key


### PR DESCRIPTION
Fix this exception:

```
writing output... [ 16%] modules/zend.feed.pubsubhubbub
Exception occurred:
  File "/usr/local/lib/python2.6/dist-packages/Pygments-1.5-py2.6.egg/pygments/lexers/__init__.py", line 80, in get_lexer_by_name
    raise ClassNotFound('no lexer for alias %r found' % _alias)
ClassNotFound: no lexer for alias u'dosini' found
The full traceback has been saved in /tmp/sphinx-err-ndKuJs.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-dev/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
make: *** [html] Error 1
```
