### PR TITLE
Typo: Flass -> Flash in Zend MVC Controller plugins

### DIFF
--- a/docs/languages/en/modules/zend.mvc.plugins.rst
+++ b/docs/languages/en/modules/zend.mvc.plugins.rst
@@ -48,7 +48,7 @@ exposes a number of methods:
 
 - ``getSessionManager()`` allows you to retrieve the session manager registered.
 
-- ``getContainer()`` returns the ``Zend\Session\Container`` instance in which the flass messages are stored.
+- ``getContainer()`` returns the ``Zend\Session\Container`` instance in which the flash messages are stored.
 
 - ``setNamespace()`` allows you to specify a specific namespace in the container in which to store or from which to
   retrieve flash messages.


### PR DESCRIPTION
Another silly typo
