### PR TITLE
Update docs/languages/en/modules/zend.form.element.rst

### DIFF
--- a/docs/languages/en/modules/zend.form.element.rst
+++ b/docs/languages/en/modules/zend.form.element.rst
@@ -176,7 +176,7 @@ Available Methods
 
 .. _zend.form.element.methods.get-messages:
 
-**setMessages**
+**getMessages**
    ``getMessages()``
 
    Returns a list of validation failure messages, if any.


### PR DESCRIPTION
fixed typo
