### PR TITLE
Update docs/languages/en/user-guide/database-and-models.rst

### DIFF
--- a/docs/languages/en/user-guide/database-and-models.rst
+++ b/docs/languages/en/user-guide/database-and-models.rst
@@ -233,7 +233,7 @@ you should commit to your version control system.You can use ``local.php``
     return array(
         'db' => array(
             'driver'         => 'Pdo',
-            'dsn'            => 'mysql:dbname=zf2tutorial;hostname=localhost',
+            'dsn'            => 'mysql:dbname=zf2tutorial;host=localhost',
             'driver_options' => array(
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES \'UTF8\''
             ),


### PR DESCRIPTION
The dsn key-word for MySQL is not "hostname" but "host".
Thanks.

http://php.net/manual/en/ref.pdo-mysql.connection.php
