### PR TITLE
Remove json syntax highlighting for code block

### DIFF
--- a/docs/languages/en/modules/zend.config.reader.rst
+++ b/docs/languages/en/modules/zend.config.reader.rst
@@ -208,7 +208,7 @@ application by using an array syntax.
 The following example illustrates a basic use of ``Zend\Config\Reader\Json`` for loading configuration data from a
 *JSON* file. Suppose we have the following *JSON* configuration file:
 
-.. code-block:: json
+.. code-block:: text
    :linenos:
 
    {
@@ -241,7 +241,7 @@ Using ``Zend\Config\Reader\Json`` we can include the content of a JSON file in a
 This is provided using the special syntax ``@include``. Suppose we have a JSON file that contains only the database
 configuration:
 
-.. code-block:: json
+.. code-block:: text
    :linenos:
 
    {
@@ -258,7 +258,7 @@ configuration:
 
 We can include this configuration in another JSON file, for instance:
 
-.. code-block:: json
+.. code-block:: text
    :linenos:
 
    {

--- a/docs/languages/en/modules/zend.config.writer.rst
+++ b/docs/languages/en/modules/zend.config.writer.rst
@@ -217,7 +217,7 @@ This example illustrates the basic use of ``Zend\Config\Writer\Json`` to create 
 
 The result of this code is a JSON string contains the following values:
 
-.. code-block:: json
+.. code-block:: text
    :linenos:
 
    { "webhost"  : "www.example.com",


### PR DESCRIPTION
To be able to render the json syntax highlighting you need at least Pygments 1.5.

Currently we have 1.4 for Ubuntu and with sphinx 1.1.3 it send a warning.

But with Debian it's pygments-1.3 and sphinx 0.6.6, and in this case it crashes:

```
writing output... [  6%] modules/zend.config.reader
Exception occurred:
  File "/usr/lib/pymodules/python2.6/pygments/lexers/__init__.py", line 80, in get_lexer_by_name
    raise ClassNotFound('no lexer for alias %r found' % _alias)
ClassNotFound: no lexer for alias u'json' found
The full traceback has been saved in /tmp/sphinx-err-TvAy1D.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-dev/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
make: *** [html] Erreur 1
```

As there are only 4 occurences in all the files, this commit replaces JSON by TEXT
@ping ezimuel
