### PR TITLE
Update docs/languages/en/modules/zend.permissions.acl.intro.rst

### DIFF
--- a/docs/languages/en/modules/zend.permissions.acl.intro.rst
+++ b/docs/languages/en/modules/zend.permissions.acl.intro.rst
@@ -171,7 +171,6 @@ For this example, ``Zend\Permissions\Acl\Role\GenericRole`` is used, but any obj
 
    use Zend\Permissions\Acl\Acl;
    use Zend\Permissions\Acl\Role\GenericRole as Role;
-   use Zend\Permissions\Acl\Resource\GenericResource as Resource;
 
    $acl = new Acl();
 


### PR DESCRIPTION
This code example focuses on creating roles.
Since Resource() is not used in the code 
example - nor it is related to the example at all - 
it should be removed, in my opinion.
