### PR TITLE
Cross platform sed fix in Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,6 +35,7 @@ ifneq ($(LANG),en)
 endif
 	@cp languages/en/conf.py tmp/$(LANG)/conf.py
 	@sed -i.bak 's/#language = None/language = "$(LANG)"/' tmp/$(LANG)/conf.py
+	@rm -f tmp/$(LANG)/conf.py.bak
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"


### PR DESCRIPTION
Ran into an error with the Makefile when running on mac os:
`sed: 1: "tmp/en/conf.py": undefined label 'mp/en/conf.py'`

Mozilla had run into something similar:
https://github.com/mozilla/pdf.js/pull/879/files

Tested the fix on mac and ubuntu linux.
