### PR TITLE
Unexpected return from UserForm callback

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.quick-start.rst
+++ b/docs/languages/en/modules/zend.service-manager.quick-start.rst
@@ -123,7 +123,7 @@ As such, you have a variety of ways to override service manager configuration se
                    $form = new SomeModule\Form\User();
 
                    // Retrieve a dependency from the service manager and inject it!
-                   $form->setInputFilter($serviceManager->get('UserInputFilter'),
+                   $form->setInputFilter($serviceManager->get('UserInputFilter'));
                    return $form;
                },
            ),


### PR DESCRIPTION
Fixed a "Parse error: syntax error, unexpected 'return' (T_RETURN)" error when using "php -l"
