### PR TITLE
Example of Hosts 

### DIFF
--- a/docs/languages/en/user-guide/skeleton-application.rst
+++ b/docs/languages/en/user-guide/skeleton-application.rst
@@ -71,9 +71,8 @@ Make sure that you update your ``/etc/hosts`` or
 is mapped to ``127.0.0.1``. The website can then be accessed using
 http://zf2-tutorial.localhost.  
 
-.. code-block:: bash
+.. code-block:: txt
 
-    127.0.0.1               localhost.localdomain localhost
     127.0.0.1               zf2-tutorial.localhost localhost
 
 If you’ve done it right, you should see something like this:


### PR DESCRIPTION
Sample code for "/etc/hosts" or "c:\windows\system32\drivers\etc\hosts" may help users to do this right.
