### PR TITLE
Update docs/languages/en/user-guide/styling-and-translations.rst

### DIFF
--- a/docs/languages/en/user-guide/styling-and-translations.rst
+++ b/docs/languages/en/user-guide/styling-and-translations.rst
@@ -16,7 +16,9 @@ list of ``Original`` strings and then type in “Tutorial” as the translation.
 
 .. image:: ../images/user-guide.styling-and-translations.poedit.png
 
-Press Save in the toolbar and poedit will create an ``en_US.mo`` file for us.
+Press Save in the toolbar and poedit will `create 
+<https://github.com/zendframework/ZendSkeletonApplication/tree/master/module/Application/language>`_ 
+an ``en_US.mo`` file for us.
 
 To remove the copyright message, we need to edit the ``Application`` module’s
 ``layout.phtml`` view script:


### PR DESCRIPTION
Corrections:
"Press Save in the toolbar and poedit will create an `en_US.mo` file for us."

Poedit doesn't create an 'en.US.mo' file. The file already exists in the Skeleton Application. 

It'd be nice to know if it modifies the file instead. Lastly the translation isn't working on Windows.

Thanks
