### PR TITLE
Update docs/languages/en/modules/zend.crypt.password.rst

### DIFF
--- a/docs/languages/en/modules/zend.crypt.password.rst
+++ b/docs/languages/en/modules/zend.crypt.password.rst
@@ -1,6 +1,6 @@
 .. _zend.crypt.password:
 
-Password secure storing
+Secure Password Storing
 =======================
 
 The ``Zend\Crypt\Password`` store a user's password in a secure way using dedicated adapters like the `bcrypt`_


### PR DESCRIPTION
fixed English and capitalization of the title.
