### PR TITLE
33 is the wrong highest value that is accepted

### DIFF
--- a/docs/languages/en/modules/zend.crypt.password.rst
+++ b/docs/languages/en/modules/zend.crypt.password.rst
@@ -38,7 +38,7 @@ To verify if a given password is valid against a bcrypt value you can use the ``
    }
 
 By default, the ``Zend\Crypt\Password\Bcrypt`` class uses a value of 14 for bcrypts cost parameter. The cost parameter is an integer between 4 to
-33. A greater value means longer execution time for bcrypt, thus more secure against brute force or
+31. A greater value means longer execution time for bcrypt, thus more secure against brute force or
 dictionary attacks.
 
 If you want to change the cost parameter of the bcrypt algorithm you can use the ``setCost()`` method.


### PR DESCRIPTION
When using 33 an exception is thrown:

The cost parameter of bcrypt must be in range 04-31

So, 31 is the right value;
