### PR TITLE
Removed $this usage when not in object context.

### DIFF
--- a/docs/languages/en/modules/zend.log.overview.rst
+++ b/docs/languages/en/modules/zend.log.overview.rst
@@ -147,14 +147,12 @@ the error along as well.
 .. code-block:: php
    :linenos:
 
-   use Zend\Log\Logger;
-   use Zend\Log\Writer\Stream as StreamWriter;
+   $logger = new Zend\Log\Logger;
+   $writer = new Zend\Log\Writer\Stream('php://output');
 
-   $logger = new Logger;
-   $writer = new StreamWriter('php://output');
    $logger->addWriter($writer);
 
-   Logger::registerErrorHandler($this->logger);
+   Logger::registerErrorHandler($logger);
 
 If you want to unregister the error handler you can use the ``unregisterErrorHandler()`` static method.
 


### PR DESCRIPTION
Line 157
is:
Logger::registerErrorHandler($this->logger);
should be:
Logger::registerErrorHandler($logger);

Or even better and to make it more consistent with other examples on the same page I would like to see this code instead (already amended):

   $logger = new Zend\Log\Logger;
   $writer = new Zend\Log\Writer\Stream('php://output');

   $logger->addWriter($writer);

   Logger::registerErrorHandler($logger);
