### PR TITLE
Update docs/languages/en/modules/zend.http.client.rst

### DIFF
--- a/docs/languages/en/modules/zend.http.client.adapters.rst
+++ b/docs/languages/en/modules/zend.http.client.adapters.rst
@@ -184,7 +184,7 @@ You can access the stream context using the following methods of ``Zend_Http_Cli
    $context = $adapter->getStreamContext();
    stream_context_set_option($context, $options);
 
-   // Now, preform the request
+   // Now, perform the request
    $response = $client->request();
 
    // If everything went well, you can now access the context again
@@ -193,9 +193,9 @@ You can access the stream context using the following methods of ``Zend_Http_Cli
 
 .. note::
 
-   Note that you must set any stream context options before using the adapter to preform actual requests. If no
-   context is set before preforming *HTTP* requests with the Socket adapter, a default stream context will be
-   created. This context resource could be accessed after preforming any requests using the ``getStreamContext()``
+   Note that you must set any stream context options before using the adapter to perform actual requests. If no
+   context is set before performing *HTTP* requests with the Socket adapter, a default stream context will be
+   created. This context resource could be accessed after performing any requests using the ``getStreamContext()``
    method.
 
 .. _zend.http.client.adapters.proxy:

--- a/docs/languages/en/modules/zend.http.client.rst
+++ b/docs/languages/en/modules/zend.http.client.rst
@@ -523,10 +523,10 @@ called, the default request method is ``GET`` (see the above example).
 
    use Zend\Http\Client;
    $client = new Client();
-   // Preforming a POST request
+   // Performing a POST request
    $response = $client->send('POST');
 
-   // Yet another way of preforming a POST request
+   // Yet another way of performing a POST request
    $client->setMethod(Client::POST);
    $response = $client->send();
 

--- a/docs/languages/fr/modules/zend.http.client.adapters.rst
+++ b/docs/languages/fr/modules/zend.http.client.adapters.rst
@@ -183,7 +183,7 @@ You can access the stream context using the following methods of ``Zend_Http_Cli
    $context = $adapter->getStreamContext();
    stream_context_set_option($context, $options);
 
-   // Now, preform the request
+   // Now, perform the request
    $response = $client->request();
 
    // If everything went well, you can now access the context again
@@ -192,9 +192,9 @@ You can access the stream context using the following methods of ``Zend_Http_Cli
 
 .. note::
 
-   Note that you must set any stream context options before using the adapter to preform actual requests. If no
-   context is set before preforming *HTTP* requests with the Socket adapter, a default stream context will be
-   created. This context resource could be accessed after preforming any requests using the ``getStreamContext()``
+   Note that you must set any stream context options before using the adapter to perform actual requests. If no
+   context is set before performing *HTTP* requests with the Socket adapter, a default stream context will be
+   created. This context resource could be accessed after performing any requests using the ``getStreamContext()``
    method.
 
 .. _zend.http.client.adapters.proxy:


### PR DESCRIPTION
Fixed misspelling of "perform"
