### PR TITLE
Logger to Zend\Log\Logger

### DIFF
--- a/docs/languages/en/modules/zend.log.overview.rst
+++ b/docs/languages/en/modules/zend.log.overview.rst
@@ -152,7 +152,7 @@ the error along as well.
 
    $logger->addWriter($writer);
 
-   Logger::registerErrorHandler($logger);
+   Zend\Log\Logger::registerErrorHandler($logger);
 
 If you want to unregister the error handler you can use the ``unregisterErrorHandler()`` static method.
 


### PR DESCRIPTION
Since there is no "use Zend\Log\Logger;"
line
Logger::registerErrorHandler($logger);
shold now be:
Zend\Log\Logger::registerErrorHandler($logger);
