### PR TITLE
Update docs/languages/en/user-guide/modules.rst

### DIFF
--- a/docs/languages/en/user-guide/modules.rst
+++ b/docs/languages/en/user-guide/modules.rst
@@ -55,6 +55,7 @@ Create ``Module.php`` in the ``Album`` module:
 
 .. code-block:: php
 
+    <?php
     // module/Album/Module.php
     namespace Album;
     


### PR DESCRIPTION
added missing php start tag
