### PR TITLE
Update docs/languages/en/user-guide/modules.rst

### DIFF
--- a/docs/languages/en/user-guide/modules.rst
+++ b/docs/languages/en/user-guide/modules.rst
@@ -99,7 +99,6 @@ classmap autoloader. Create ``autoload_classmap.php`` with these contents:
 
 .. code-block:: php
 
-    <?php
     // module/Album/autoload_classmap.php:
     return array();
 


### PR DESCRIPTION
According to https://github.com/zendframework/zf2-documentation/pull/216#issuecomment-8202575 the <?php start tag should be ommited.
