### PR TITLE
Mistyped variable and syntax error

### DIFF
--- a/docs/languages/en/modules/zend.input-filter.intro.rst
+++ b/docs/languages/en/modules/zend.input-filter.intro.rst
@@ -71,10 +71,10 @@ uses filtering without validation.
          ->attachByName('stringtrim')
          ->attachByName('alpha');
 
-   $inputfilter = new InputFilter();
-   $inputfilter->add($input, 'foo')
+   $inputFilter = new InputFilter();
+   $inputFilter->add($input)
                ->setData(array(
-                   'foo' => ' Bar3 ';
+                   'foo' => ' Bar3 ',
                ));
 
    echo "Before:\n";


### PR DESCRIPTION
// array argument separator set to correct character ','. Was ';'.
// mistyped variable $inputFilter. Was $inputfilter.
// removed Input name parameter from $inputfilter->add since Input gets its name set in its constructor. Was $inputfilter->add($input, 'foo');
