### PR TITLE
Input factory expects the "type" to be a class

### DIFF
--- a/docs/languages/en/modules/zend.input-filter.intro.rst
+++ b/docs/languages/en/modules/zend.input-filter.intro.rst
@@ -132,7 +132,7 @@ appropriate object. You may create either ``Input`` or ``InputFilter`` objects i
 
    // Adding a single input
    $filter->add(array(
-       'name' => 'password',
+       'name' => 'username',
        'required' => true,
        'validators' => array(
            array(
@@ -141,15 +141,15 @@ appropriate object. You may create either ``Input`` or ``InputFilter`` objects i
            array(
                'name' => 'string_length',
                'options' => array(
-                   'min' => 8
+                   'min' => 5
                ),
            ),
        ),
    ));
 
-   // Adding an input filter composing a single input to the current filter
+   // Adding another input filter what also contains a single input. Merging both.
    $filter->add(array(
-       'type' => 'Zend\Filter\InputFilter',
+       'type' => 'Zend\InputFilter\InputFilter',
        'password' => array(
            'name' => 'password',
            'required' => true,


### PR DESCRIPTION
Changed 'Zend\Filter\InputFilter' to 'Zend\InputFilter\InputFilter'

However:
looks like the second filter can not see the data set by 'setData'

Example:
use Zend\InputFilter\InputFilter;

$filter = new InputFilter();

// Adding a single input
$filter->add(array(
    'name' => 'username',
    'required' => true,
    'validators' => array(
        array(
            'name' => 'not_empty',
        ),
        array(
            'name' => 'string_length',
            'options' => array(
                'min' => 5
            ),
        ),
    ),
));

// Adding another input filter what also contains a single input. Merging both.
$filter->add(array(
    'type' => 'Zend\InputFilter\InputFilter',
    'password' => array(
        'name' => 'password',
        'required' => true,
        'validators' => array(
            array(
                'name' => 'not_empty',
            ),
            array(
                'name' => 'string_length',
                'options' => array(
                    'min' => 8
                ),
            ),
        ),
    ),
));

$filter->setData(array('username' => 'foobar', 'password' => 'bar'));

if (!$filter->isValid()) {
    foreach ($filter->getInvalidInput() as $error) {
        echo 'Invalid:'; print_r($error->getMessages());
    }
}
