### PR TITLE
dom->query() should be dom->execute()

### DIFF
--- a/docs/languages/en/modules/zend.dom.query.rst
+++ b/docs/languages/en/modules/zend.dom.query.rst
@@ -85,7 +85,7 @@ above:
    use Zend\Dom\Query;
 
    $dom = new Query($html);
-   $results = $dom->query('.foo .bar a');
+   $results = $dom->execute('.foo .bar a');
 
    $count = count($results); // get number of matches: 4
    foreach ($results as $result) {


### PR DESCRIPTION
$results = $dom->query('.foo .bar a'); should be $results = $dom->execute('.foo .bar a');
