### PR TITLE
fix variable in pass in init function. missing 'a' character.

### DIFF
--- a/docs/languages/en/modules/zend.module-manager.module-class.rst
+++ b/docs/languages/en/modules/zend.module-manager.module-class.rst
@@ -106,7 +106,7 @@ manager's "loadModules.post" event makes this easy.
 
    class Module
    {
-       public function init(ModuleManager $moduleManger)
+       public function init(ModuleManager $moduleManager)
        {
            // Remember to keep the init() method as lightweight as possible
            $events = $moduleManager->getEventManager();


### PR DESCRIPTION
$moduleManger should be $moduleManager. miss 'a' character.
