### PR TITLE
[View] Quickstart's $locator->get('Zend\View\Strategy\JsonStrategy') is out of date.

### DIFF
--- a/docs/languages/en/modules/zend.view.quick-start.rst
+++ b/docs/languages/en/modules/zend.view.quick-start.rst
@@ -661,7 +661,6 @@ priority to ensure they match before the ``PhpRendererStrategy``. As an example,
            $app          = $e->getTarget();
            $locator      = $app->getServiceManager();
            $view         = $locator->get('Zend\View\View');
-           // ViewJsonStrategy is aliased at Zend\Mvc\Service\ServiceListenerFactory
            $jsonStrategy = $locator->get('ViewJsonStrategy');
 
            // Attach strategy, which is a listener aggregate, at high priority


### PR DESCRIPTION
update: default locator getting about JsonStrategy.
