### PR TITLE
Update docs/languages/en/modules/zend.form.collections.rst

### DIFF
--- a/docs/languages/en/modules/zend.form.collections.rst
+++ b/docs/languages/en/modules/zend.form.collections.rst
@@ -477,7 +477,7 @@ not forms. And only ``Form`` instances can be validated. So here is the form :
                 'name' => 'submit',
                 'attributes' => array(
                     'type' => 'submit',
-                    'value' => 'Envoyer'
+                    'value' => 'Send'
                 )
             ));
         }
@@ -800,7 +800,7 @@ all the elements we want to validate.  Our ``CreateForm`` now looks like this:
                 'name' => 'submit',
                 'attributes' => array(
                     'type' => 'submit',
-                    'value' => 'Envoyer'
+                    'value' => 'Send'
                 )
             ));
     


### PR DESCRIPTION
Ready to merge!
1. 'CreateProduct' form button added a value. The whole form now looks like on the example png http://framework.zend.com/images/manual/zend.form.collections.view.png
2. 'BrandFieldset' label is not needed since it is not used anywhere. Not even as an example since 'CategoryFieldset' has an example of 'setLabel' usage.
