### PR TITLE
Fix variable names in example in zend.paginator.usage

### DIFF
--- a/docs/languages/en/modules/zend.paginator.usage.rst
+++ b/docs/languages/en/modules/zend.paginator.usage.rst
@@ -119,8 +119,8 @@ following setup:
    {
        public function count()
        {
-           $sql = new Zend\Db\Sql\Select();
-           $sql->from('item_counts')->columns(array('c'=>'post_count'));
+           $select = new Zend\Db\Sql\Select();
+           $select->from('item_counts')->columns(array('c'=>'post_count'));
 
            $statement = $this->sql->prepareStatementForSqlObject($select);
            $result    = $statement->execute();


### PR DESCRIPTION
Under section `The DbSelect Adapter`, example mixes $sql and $select:

``` php
$sql = new Zend\Db\Sql\Select();
$sql->from('item_counts')->columns(array('c'=>'post_count'));
$statement = $this->sql->prepareStatementForSqlObject($select);
```

`$sql` is incorrect.  Corrected example:

``` php
$select= new Zend\Db\Sql\Select();
$select->from('item_counts')->columns(array('c'=>'post_count'));
$statement = $this->sql->prepareStatementForSqlObject($select);
```
