### PR TITLE
Update to the form doc

### DIFF
--- a/docs/languages/en/modules/zend.form.element.captcha.rst
+++ b/docs/languages/en/modules/zend.form.element.captcha.rst
@@ -31,6 +31,24 @@ adapters are available.
    $form = new Form('my-form');
    $form->add($captcha);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+	use Zend\Captcha;
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Captcha',
+    	'name' => 'captcha',
+    	'options => array(
+    		'label' => 'Please verify you are human',
+    		'captcha' => new Captcha\Dumb(),
+    	),
+    ));
+    
 .. _zend.form.element.captcha.methods:
 
 Public Methods

--- a/docs/languages/en/modules/zend.form.element.checkbox.rst
+++ b/docs/languages/en/modules/zend.form.element.checkbox.rst
@@ -26,6 +26,26 @@ This element automatically adds a ``"type"`` attribute of value ``"checkbox"``.
 
    $form = new Form('my-form');
    $form->add($checkbox);
+   
+Using the array notation:
+
+.. code-block:: php
+   :linenos:
+   
+    use Zend\Form\Form;
+    
+   	$form = new Form('my-form');   	
+   	$form->add(array(
+   		'type' => 'Zend\Form\Element\Checkbox',
+   		'name' => 'checkbox',
+   		'options' => array(
+   			'label' => 'A checkbox',
+   			'use_hidden_element' => true,
+   			'checked_value' => 'good',
+   			'unchecked_value' => 'bad'
+   		)
+   	));
+   
 
 .. _zend.form.element.checkbox.methods:
 

--- a/docs/languages/en/modules/zend.form.element.collection.rst
+++ b/docs/languages/en/modules/zend.form.element.collection.rst
@@ -1,7 +1,7 @@
 Collection Element
 ^^^^^^^^^^^^^^^^^^
 
-Sometimes, you may want to add input (or a set of inputs) multiple times, either because you don't want to duplicate code, or because you does not know in advance how many elements you need (in the case of elements dynamically added to a form using JavaScript, for instance).
+Sometimes, you may want to add input (or a set of inputs) multiple times, either because you don't want to duplicate code, or because you does not know in advance how many elements you need (in the case of elements dynamically added to a form using JavaScript, for instance). For more information about Collection, please refer to :ref:`Zend\\Collection tutorial <zend.form.collections>`
 
 ``Zend\Form\Element\Collection`` is meant to be paired with the ``Zend\Form\View\Helper\FormCollection``.
 
@@ -25,6 +25,25 @@ Basic Usage
    $form = new Form('my-form');
    $form->add($colors);
 
+Using the array notation:
+
+.. code-block:: php
+   :linenos:
+   
+    use Zend\Form\Element;
+    use Zend\Form\Form;
+    
+   	$form = new Form('my-form');   	
+   	$form->add(array(
+   		'type' => 'Zend\Form\Element\Collection',
+   		'options' => array(
+   			'label' => 'Colors',
+   			'count' => 2,
+   			'should_create_template' => true,
+   			'target_element' => new Element\Color()
+   		)
+   	));
+
 .. _zend.form.element.collection.methods:
 
 Public Methods
@@ -35,12 +54,12 @@ The following methods are in addition to the inherited :ref:`methods of Zend\\Fo
 .. function:: setOptions(array $options)
    :noindex:
 
-   Set options for an element of type Collection. Accepted options, in addition to the inherited options of Zend\\Form\\Element <zend.form.element.methods.set-options>` , are: ``"target_element"``, ``"count"``, ``"allow_add"``, ``"should_create_template"`` and ``"template_placeholder"`` , which call ``setTargetElement``, ``setCount``, ``setAllowAdd``, ``setShouldCreateTemplate`` and ``setTemplatePlaceholder`` , respectively.
+   Set options for an element of type Collection. Accepted options, in addition to the inherited options of Zend\\Form\\Element <zend.form.element.methods.set-options>` , are: ``"target_element"``, ``"count"``, ``"allow_add"``, ``"allow_remove"``, ``"should_create_template"`` and ``"template_placeholder"``. Those option keys respectively call call ``setTargetElement``, ``setCount``, ``setAllowAdd``, ``setAllowRemove``, ``setShouldCreateTemplate`` and ``setTemplatePlaceholder``.
 
 .. function:: setCount($count)
    :noindex:
 
-   Defines how many times the target element will be rendered by the ``Zend/Form/View/Helper/FormCollection`` view helper.
+   Defines how many times the target element will be initially rendered by the ``Zend/Form/View/Helper/FormCollection`` view helper.
 
 .. function:: getCount()
    :noindex:

--- a/docs/languages/en/modules/zend.form.element.color.rst
+++ b/docs/languages/en/modules/zend.form.element.color.rst
@@ -26,6 +26,22 @@ This element automatically adds a ``"type"`` attribute of value ``"color"``.
    $form = new Form('my-form');
    $form->add($color);
 
+Here is the same example using the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Color',
+    	'name' => 'color',
+    	'options => array(
+    		'label' => 'Background color'
+    	)
+    ));
+
 .. _zend.form.element.color.methods:
 
 Public Methods

--- a/docs/languages/en/modules/zend.form.element.csrf.rst
+++ b/docs/languages/en/modules/zend.form.element.csrf.rst
@@ -25,6 +25,24 @@ This element automatically adds a ``"type"`` attribute of value ``"hidden"``.
    $form = new Form('my-form');
    $form->add($csrf);
 
+You can change the options of the CSRF validator using the ``setCsrfValidatorOptions`` function, or by using the ``"csrf_options"`` key. Here is an example using the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Csrf',
+    	'name' => 'csrf',
+    	'options => array(
+    		'csrf_options' => array(
+    			'timeout' => 600
+    		)
+    	)
+    ));
+
 .. _zend.form.element.csrf.methods:
 
 Public Methods
@@ -40,3 +58,27 @@ The following methods are in addition to the inherited :ref:`methods of Zend\\Fo
    ``Zend\Validator\Csrf`` to validate the *CSRF* value.
 
    :rtype: array
+   
+.. function:: setCsrfValidatorOptions(array $options)
+   :noindex:
+
+   Set the options that are used by the CSRF validator.
+
+.. function:: getCsrfValidatorOptions()
+   :noindex:
+
+   Get the options that are used by the CSRF validator.
+   
+   :rtype: array
+   
+.. function:: setCsrfValidator(CsrfValidator $validator)
+   :noindex:
+
+   Override the default CSRF validator by setting another one.
+
+.. function:: getCsrfValidator()
+   :noindex:
+
+   Get the CSRF validator.
+   
+   :rtype: CsrfValidator 

--- a/docs/languages/en/modules/zend.form.element.date.rst
+++ b/docs/languages/en/modules/zend.form.element.date.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"date"``.
    $form = new Form('my-form');
    $form->add($date);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Date',
+    	'name' => 'appointment-date',
+    	'options => array(
+    		'label' => 'Appointment Date'
+    	),
+    	'attributes' => array(
+    		'min' => '2012-01-01',
+    		'max' => '2020-01-01',
+    		'step' => '1', // days; default step interval is 1 day
+    	)
+    ));
+
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.element.date.time.local.rst
+++ b/docs/languages/en/modules/zend.form.element.date.time.local.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"datetime-loca
    $form = new Form('my-form');
    $form->add($dateTimeLocal);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\DateTimeLocal',
+    	'name' => 'appointment-date-time',
+    	'options => array(
+    		'label' => 'Appointment Date'
+    	),
+    	'attributes' => array(
+    		'min' => '2010-01-01T00:00:00',
+    		'max' => '2020-01-01T00:00:00',
+    		'step' => '1', // minutes; default step interval is 1 min
+    	)
+    ));
+
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.element.date.time.rst
+++ b/docs/languages/en/modules/zend.form.element.date.time.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"datetime"``.
    $form = new Form('my-form');
    $form->add($dateTime);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\DateTime',
+    	'name' => 'appointement-date-time',
+    	'options => array(
+    		'label' => 'Appointment Date/Time'
+    	),
+    	'attributes' => array(
+    		'min' => '2010-01-01T00:00:00Z',
+    		'max' => '2020-01-01T00:00:00Z',
+    		'step' => '1', // minutes; default step interval is 1 mint
+    	)
+    ));
+    
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.element.email.rst
+++ b/docs/languages/en/modules/zend.form.element.email.rst
@@ -34,6 +34,33 @@ This element automatically adds a ``"type"`` attribute of value ``"email"``.
        ->setAttribute('multiple', true);
    $form->add($emails);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Email',
+    	'name' => 'email',
+    	'options => array(
+    		'label' => 'Email Address'
+    	),
+    ));
+    
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Email',
+    	'name' => 'emails',
+    	'options' => array(
+    		'label' => 'Email Addresses'
+    	),
+    	'attributes' => array(
+    		'multiple' => true
+    	)
+    ));
+    
 .. note::
 
    Note: the ``multiple`` attribute should be set prior to calling Zend\\Form::prepare(). Otherwise, the default

--- a/docs/languages/en/modules/zend.form.element.hidden.rst
+++ b/docs/languages/en/modules/zend.form.element.hidden.rst
@@ -26,3 +26,19 @@ This element automatically adds a ``"type"`` attribute of value ``"hidden"``.
 
    $form = new Form('my-form');
    $form->add($hidden);
+
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Hidden',
+    	'name' => 'my-hidden',
+    	'attributes' => array(
+    		'value' => 'foo'
+    	)
+    ));

--- a/docs/languages/en/modules/zend.form.element.month.rst
+++ b/docs/languages/en/modules/zend.form.element.month.rst
@@ -31,6 +31,27 @@ This element automatically adds a ``"type"`` attribute of value ``"month"``.
 
    $form = new Form('my-form');
    $form->add($month);
+   
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Month',
+    	'name' => 'month',
+    	'options => array(
+    		'label' => 'Month'
+    	),
+    	'attributes' => array(
+    		'min' => '2012-12',
+    		'max' => '2020-01',
+    		'step' => '1', // months; default step interval is 1 month
+    	)
+    ));
 
 .. note::
 

--- a/docs/languages/en/modules/zend.form.element.multicheckbox.rst
+++ b/docs/languages/en/modules/zend.form.element.multicheckbox.rst
@@ -1,0 +1,78 @@
+.. _zend.form.element.multicheckbox:
+
+MultiCheckbox Element
+^^^^^^^^^^^^^^^^^^^^^
+
+``Zend\Form\Element\MultiCheckbox`` is meant to be paired with the ``Zend/Form/View/Helper/FormMultiCheckbox`` for HTML inputs with type checkbox. This element adds an ``InArray`` validator to its input filter specification in order to validate on the server if the checkbox contains values from the multiple checkboxes.
+
+.. _zend.form.element.multicheckbox.usage:
+
+Basic Usage
+"""""""""""
+
+This element automatically adds a ``"type"`` attribute of value ``"checkbox"`` for every checkboxes.
+
+.. code-block:: php
+   :linenos:
+
+   	use Zend\Form\Element;
+   	use Zend\Form\Form;
+
+   	$multiCheckbox = new Element\MultiCheckbox('multi-checkbox');
+   	$multiCheckbox->setLabel('What do you like ?');
+   	$multiCheckbox->setValueOptions(array(
+   		array(
+   			'0' => 'Apple',
+   			'1' => 'Orange',
+   			'2' => 'Lemon'
+   		)
+   	));
+
+   	$form = new Form('my-form');
+   	$form->add($multiCheckbox);
+   
+Using the array notation:
+
+.. code-block:: php
+   :linenos:
+   
+    use Zend\Form\Form;
+    
+   	$form = new Form('my-form');   	
+   	$form->add(array(
+   		'type' => 'Zend\Form\Element\MultiCheckbox',
+   		'name' => 'multi-checkbox'
+   		'options' => array(
+   			'label' => 'What do you like ?',
+   			'value_options' => array(
+   				'0' => 'Apple',
+   				'1' => 'Orange',
+   				'2' => 'Lemon',
+   			),
+   		)
+   	));
+   
+
+.. _zend.form.element.multicheckbox.methods:
+
+Public Methods
+""""""""""""""
+
+The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\Checkbox <zend.form.element.checkbox.methods>` .
+
+.. function:: setOptions(array $options)
+   :noindex:
+
+   Set options for an element of type Checkbox. Accepted options, in addition to the inherited options of Zend\\Form\\Element\\Checkbox <zend.form.element.checkbox.methods.set-options>` , are: ``"value_options"``, which call ``setValueOptions``.
+   
+.. function:: setValueOptions(array $options)
+   :noindex:
+
+   Set the value options for every checkbox of the multi-checkbox. The array must contain a key => value for every checkbox.
+
+.. function:: getValueOptions()
+   :noindex:
+
+   Return the value options.
+
+   :rtype: array

--- a/docs/languages/en/modules/zend.form.element.number.rst
+++ b/docs/languages/en/modules/zend.form.element.number.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"number"``.
    $form = new Form('my-form');
    $form->add($number);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Number',
+    	'name' => 'quantity',
+    	'options => array(
+    		'label' => 'Quantity'
+    	),
+    	'attributes' => array(
+    		'min' => '0',
+    		'max' => '10',
+    		'step' => '1', // default step interval is 1
+    	)
+    ));
+
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.element.radio.rst
+++ b/docs/languages/en/modules/zend.form.element.radio.rst
@@ -1,0 +1,59 @@
+.. _zend.form.element.radio:
+
+Radio Element
+^^^^^^^^^^^^^
+
+``Zend\Form\Element\Radio`` is meant to be paired with the ``Zend/Form/View/Helper/FormRadio`` for HTML inputs with type radio. This element adds an ``InArray`` validator to its input filter specification in order to validate on the server if the value is contains within the radio value elements.
+
+.. _zend.form.element.radio.usage:
+
+Basic Usage
+"""""""""""
+
+This element automatically adds a ``"type"`` attribute of value ``"radio"`` for every radio.
+
+.. code-block:: php
+   :linenos:
+
+   	use Zend\Form\Element;
+   	use Zend\Form\Form;
+
+   	$radio = new Element\Radio('gender');
+   	$radio->setLabel('What is your gender ?');
+   	$radio->setValueOptions(array(
+   		array(
+   			'0' => 'Female',
+   			'1' => 'Male',
+   		)
+   	));
+
+   	$form = new Form('my-form');
+   	$form->add($radio);
+   
+Using the array notation:
+
+.. code-block:: php
+   :linenos:
+   
+    use Zend\Form\Form;
+    
+   	$form = new Form('my-form');   	
+   	$form->add(array(
+   		'type' => 'Zend\Form\Element\Radio',
+   		'name' => 'gender'
+   		'options' => array(
+   			'label' => 'What is your gender ?',
+   			'value_options' => array(
+   				'0' => 'Female',
+   				'1' => 'Male',
+   			),
+   		)
+   	));
+   
+
+.. _zend.form.element.radio.methods:
+
+Public Methods
+""""""""""""""
+
+All the methods from the inherited :ref:`methods of Zend\\Form\\Element\\MultiCheckbox <zend.form.element.multicheckbox.methods>` are also available for this element.

--- a/docs/languages/en/modules/zend.form.element.range.rst
+++ b/docs/languages/en/modules/zend.form.element.range.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"range"``.
    $form = new Form('my-form');
    $form->add($range);
 
+Here is with the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Range',
+    	'name' => 'range',
+    	'options => array(
+    		'label' => 'Minimum and Maximum Amount'
+    	),
+    	'attributes' => array(
+    		'min' => 0, // default minimum is 0
+    		'max' => 100, // default maximum is 100
+    		'step' => 1 // default interval is 1
+    	)
+    ));
+
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.element.rst
+++ b/docs/languages/en/modules/zend.form.element.rst
@@ -55,6 +55,18 @@ Public Methods
    Return the name for this element.
 
    :rtype: string
+   
+.. function:: setValue(string $value)
+   :noindex:
+
+   Set the value for this element.
+
+.. function:: getValue()
+   :noindex:
+
+   Return the value for this element.
+
+   :rtype: string
 
 .. function:: setLabel(string $label)
    :noindex:

--- a/docs/languages/en/modules/zend.form.element.select.rst
+++ b/docs/languages/en/modules/zend.form.element.select.rst
@@ -1,0 +1,138 @@
+.. _zend.form.element.select:
+
+Select Element
+^^^^^^^^^^^^^^
+
+``Zend\Form\Element\Select`` is meant to be paired with the ``Zend/Form/View/Helper/FormSelect`` for HTML inputs with type select. This element adds an ``InArray`` validator to its input filter specification in order to validate on the server if the selected value belongs to the values. This element can be used as a multi-select element by adding the "multiple" HTML attribute to the element.
+
+.. _zend.form.element.select.usage:
+
+Basic Usage
+"""""""""""
+
+This element automatically adds a ``"type"`` attribute of value ``"select"``.
+
+.. code-block:: php
+   :linenos:
+
+   	use Zend\Form\Element;
+   	use Zend\Form\Form;
+
+   	$select = new Element\Select('language');
+   	$select->setLabel('Which is your mother tongue?');
+   	$select->setValueOptions(array(
+   		'0' => 'French',
+   		'1' => 'English',
+   		'2' => 'Japanese',
+   		'3' => 'Chinese',
+   	));
+
+   	$form = new Form('language');
+   	$form->add($select);
+   
+Using the array notation:
+
+.. code-block:: php
+   :linenos:
+   
+    use Zend\Form\Form;
+    
+   	$form = new Form('my-form');   	
+   	$form->add(array(
+   		'type' => 'Zend\Form\Element\Select',
+   		'name' => 'language'
+   		'options' => array(
+   			'label' => 'Which is your mother tongue?',
+   			'value_options' => array(
+   				'0' => 'French',
+   				'1' => 'English',
+   				'2' => 'Japanese',
+   				'3' => 'Chinese',
+   			),
+   		)
+   	));
+   
+You can add an empty option (option with no value) using the ``"empty_option"`` option:
+
+.. code-block:: php
+   :linenos:
+   
+    use Zend\Form\Form;
+    
+   	$form = new Form('my-form');   	
+   	$form->add(array(
+   		'type' => 'Zend\Form\Element\Select',
+   		'name' => 'language'
+   		'options' => array(
+   			'label' => 'Which is your mother tongue?',
+   			'empty_option' => 'Please choose your language',
+   			'value_options' => array(
+   				'0' => 'French',
+   				'1' => 'English',
+   				'2' => 'Japanese',
+   				'3' => 'Chinese',
+   			),
+   		)
+   	));
+   
+Option groups are also supported. You just need to add an 'options' key to the value options.
+
+.. code-block:: php
+   :linenos:
+
+   	use Zend\Form\Element;
+   	use Zend\Form\Form;
+
+   	$select = new Element\Select('language');
+   	$select->setLabel('Which is your mother tongue?');
+   	$select->setValueOptions(array(
+   		'options' => array(
+   			'European languages' => array(
+   				'0' => 'French',
+   				'1' => 'Italian',
+   			),
+   			'Asian languages' => array(
+   				'2' => 'Japanese',
+   				'3' => 'Chinese',
+   			)
+   		)   		
+   	));
+
+   	$form = new Form('language');
+   	$form->add($select);
+
+.. _zend.form.element.select.methods:
+
+Public Methods
+""""""""""""""
+
+The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element <zend.form.element.methods>` .
+
+.. function:: setOptions(array $options)
+   :noindex:
+
+   Set options for an element of type Checkbox. Accepted options, in addition to the inherited options of Zend\\Form\\Element\\Checkbox <zend.form.element.checkbox.methods.set-options>` , are: ``"value_options"`` and ``"empty_option"``, which call ``setValueOptions`` and ``setEmptyOption``, respectively.
+   
+.. function:: setValueOptions(array $options)
+   :noindex:
+
+   Set the value options for every checkbox of the multi-checkbox. The array must contain a key => value for every checkbox.
+
+.. function:: getValueOptions()
+   :noindex:
+
+   Return the value options.
+
+   :rtype: array
+   
+.. function:: setEmptyOption($emptyOption)
+   :noindex:
+
+   Optionally set a label for an empty option (option with no value). It is set to "null" by default, which means that no empty option will be rendered.
+
+.. function:: setEmptyOption()
+   :noindex:
+
+   Get the label for the empty option (null if none).
+
+   :rtype: string

--- a/docs/languages/en/modules/zend.form.element.time.rst
+++ b/docs/languages/en/modules/zend.form.element.time.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"time"``.
    $form = new Form('my-form');
    $form->add($time);
 
+Here is the same example using the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Month',
+    	'name' => 'time',
+    	'options => array(
+    		'label' => 'Time'
+    	),
+    	'attributes' => array(
+    		'min' => '00:00:00',
+    		'max' => '23:59:59',
+    		'step' => '60', // seconds; default step interval is 60 seconds
+    	)
+    ));
+
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.element.url.rst
+++ b/docs/languages/en/modules/zend.form.element.url.rst
@@ -25,6 +25,22 @@ This element automatically adds a ``"type"`` attribute of value ``"url"``.
 
    $form = new Form('my-form');
    $form->add($url);
+   
+Here is the same example using the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Url',
+    	'name' => 'webpage-url',
+    	'options => array(
+    		'label' => 'Webpage URL'
+    	)
+    ));
 
 .. _zend.form.element.url.methods:
 

--- a/docs/languages/en/modules/zend.form.element.week.rst
+++ b/docs/languages/en/modules/zend.form.element.week.rst
@@ -32,6 +32,27 @@ This element automatically adds a ``"type"`` attribute of value ``"week"``.
    $form = new Form('my-form');
    $form->add($week);
 
+Here is the same example using the array notation:
+
+.. code-block:: php
+   :linenos:
+
+    use Zend\Form\Form;
+
+    $form = new Form('my-form');
+    $form->add(array(
+    	'type' => 'Zend\Form\Element\Week',
+    	'name' => 'week',
+    	'options => array(
+    		'label' => 'Week'
+    	),
+    	'attributes' => array(
+    		'min' => '2012-W01',
+    		'max' => '2020-W01',
+    		'step' => '1', // weeks; default step interval is 1 week
+    	)
+    ));
+    
 .. note::
 
    Note: the ``min``, ``max``, and ``step`` attributes should be set prior to calling Zend\\Form::prepare().

--- a/docs/languages/en/modules/zend.form.elements.rst
+++ b/docs/languages/en/modules/zend.form.elements.rst
@@ -24,9 +24,11 @@ Standard Elements
 .. include:: zend.form.element.checkbox.rst
 .. include:: zend.form.element.collection.rst
 .. include:: zend.form.element.csrf.rst
-.. include:: zend.form.element.email.rst
 .. include:: zend.form.element.hidden.rst
-.. include:: zend.form.element.url.rst
+.. include:: zend.form.element.multicheckbox.rst
+.. include:: zend.form.element.radio.rst
+.. include:: zend.form.element.select.rst
+
 
 HTML5 Elements
 --------------
@@ -35,8 +37,10 @@ HTML5 Elements
 .. include:: zend.form.element.date.rst
 .. include:: zend.form.element.date.time.rst
 .. include:: zend.form.element.date.time.local.rst
+.. include:: zend.form.element.email.rst
 .. include:: zend.form.element.month.rst
 .. include:: zend.form.element.number.rst
 .. include:: zend.form.element.range.rst
 .. include:: zend.form.element.time.rst
+.. include:: zend.form.element.url.rst
 .. include:: zend.form.element.week.rst

--- a/docs/languages/en/modules/zend.form.quick-start.rst
+++ b/docs/languages/en/modules/zend.form.quick-start.rst
@@ -15,7 +15,7 @@ validated values.
 
 .. _zend.form.quick-start.programmatic:
 
-.. rubric:: Programmatic Form Creation
+## Programmatic Form Creation
 
 If nothing else, you can simply start creating elements, fieldsets, and forms and wiring them together.
 
@@ -35,11 +35,8 @@ If nothing else, you can simply start creating elements, fieldsets, and forms an
        'type'  => 'text'
    ));
 
-   $email = new Element('email');
+   $email = new Element\Email('email');
    $email->setLabel('Your email address');
-   $email->setAttributes(array(
-       'type'  => 'email'
-   ));
 
    $subject = new Element('subject');
    $subject->setLabel('Subject');
@@ -47,11 +44,8 @@ If nothing else, you can simply start creating elements, fieldsets, and forms an
        'type'  => 'text'
    ));
 
-   $message = new Element('message');
+   $message = new Element\Textarea('message');
    $message->setLabel('Message');
-   $message->setAttributes(array(
-       'type'  => 'textarea'
-   ));
 
    $captcha = new Element\Captcha('captcha');
    $captcha->setCaptcha(new Captcha\Dumb());
@@ -107,7 +101,7 @@ Regardles of approach, as you can see, this can be tedious.
 
 .. _zend.form.quick-start.factory:
 
-.. rubric:: Creation via Factory
+## Creation via Factory
 
 You can create the entire form, and input filter, using the ``Factory``. This is particularly nice if you want to
 store your forms as pure configuration; you can simply pass the configuration to the factory and be done.
@@ -133,13 +127,11 @@ store your forms as pure configuration; you can simply pass the configuration to
            ),
            array(
                'spec' => array(
+                   'type' => 'Zend\Form\Element\Email',
                    'name' => 'email',
                    'options' => array(
                        'label' => 'Your email address',
-                   ),
-                   'attributes' => array(
-                       'type'  => 'email',
-                   ),
+                   )
                ),
            ),
            array(
@@ -155,13 +147,11 @@ store your forms as pure configuration; you can simply pass the configuration to
            ),
            array(
                'spec' => array(
+                   'type' => 'Zend\Form\Element\Textarea',
                    'name' => 'message',
                    'options' => array(
                        'label' => 'Message',
-                   ),
-                   'attributes' => array(
-                       'type'  => 'textarea',
-                   ),
+                   )
                ),
            ),
            array(
@@ -235,13 +225,11 @@ If we wanted to use fieldsets, as we demonstrated in the previous example, we co
                        ),
                    ),
                    array(
+                       'type' => 'Zend\Form\Element\Email',
                        'name' => 'email',
                        'options' => array(
                            'label' => 'Your email address',
                		   ),
-                       'attributes' => array(
-                           'type'  => 'email',
-                       ),
                    ),
                ),
            ),
@@ -258,13 +246,10 @@ If we wanted to use fieldsets, as we demonstrated in the previous example, we co
                        ),
                    ),
                    array(
-                       'name' => 'message',
+                       'type' => 'Zend\Form\Element\Textarea',
                        'options' => array(
                            'label' => 'Message',
                		   ),
-                       'attributes' => array(
-                           'type'  => 'textarea',
-                       ),
                    ),
                ),
            ),
@@ -307,7 +292,7 @@ significant whitespace.
 
 .. _zend.form.quick-start.extension:
 
-.. rubric:: Factory-backed Form Extension
+## Factory-backed Form Extension
 
 The default ``Form`` implementation is backed by the ``Factory``. This allows you to extend it, and define your
 form internally. This has the benefit of allowing a mixture of programmatic and factory-backed creation, as well as
@@ -347,12 +332,10 @@ defining a form for re-use in your application.
                ),
            ));
            $this->add(array(
+               'type' => 'Zend\Form\Element\Email',
                'name' => 'email',
                'options' => array(
                    'label' => 'Your email address',
-               ),
-               'attributes' => array(
-                   'type'  => 'email',
                ),
            ));
            $this->add(array(
@@ -365,12 +348,10 @@ defining a form for re-use in your application.
                ),
            ));
            $this->add(array(
+               'type' => 'Zend\Form\Element\Textarea',
                'name' => 'message',
                'options' => array(
                    'label' => 'Message',
-               ),
-               'attributes' => array(
-                   'type'  => 'textarea',
                ),
            ));
            $this->add(array(
@@ -406,7 +387,7 @@ it elsewhere in our application and inject it into the form.
 
 .. _zend.form.quick-start.validation:
 
-.. rubric:: Validating Forms
+## Validating Forms
 
 Validating forms requires three steps. First, the form must have an input filter attached. Second, you must inject
 the data to validate into the form. Third, you validate the form. If invalid, you can retrieve the error messages,
@@ -445,7 +426,7 @@ You can get the raw data if you want, by accessing the composed input filter.
 
 .. _zend.form.quick-start.input-specification:
 
-.. rubric:: Hinting to the Input Filter
+## Hinting to the Input Filter
 
 Often, you'll create elements that you expect to behave in the same way on each usage, and for which you'll want
 specific filters or validation as well. Since the input filter is a separate object, how can you achieve these
@@ -461,41 +442,77 @@ they must implement ``Zend\InputFilter\InputFilterProviderInterface``, which def
 ``getInputFilterSpecification()`` method.
 
 In the case of an element, the ``getInputSpecification()`` method should return data to be used by the input filter
-factory to create an input.
+factory to create an input. Every HTML5 (email, url, color…) elements have a built-in element that use this logic. For instance, here is how the ``Zend\Form\Element\Color`` element is defined:
 
 .. code-block:: php
    :linenos:
 
-   namespace Contact\Form;
+    namespace Zend\Form\Element;
 
-   use Zend\Form\Element;
-   use Zend\InputFilter\InputProviderInterface;
-   use Zend\Validator;
-
-   class EmailElement extends Element implements InputProviderInterface
-   {
-       protected $attributes = array(
-           'type' => 'email',
-       );
-
-       public function getInputSpecification()
-       {
-           return array(
-               'name'     => $this->getName(),
-               'required' => true,
-               'filters'  => array(
-                   array('name' => 'Zend\Filter\StringTrim'),
-               ),
-               'validators' => array(
-                   new Validator\EmailAddress(),
-               ),
-           );
-       }
-   }
+	use Zend\Form\Element;
+	use Zend\InputFilter\InputProviderInterface;
+	use Zend\Validator\Regex as RegexValidator;
+	use Zend\Validator\ValidatorInterface;
+	
+	/**
+	 * @category   Zend
+	 * @package    Zend_Form
+	 * @subpackage Element
+	 */
+	class Color extends Element implements InputProviderInterface
+	{
+	    /**
+	     * Seed attributes
+	     *
+	     * @var array
+	     */
+	    protected $attributes = array(
+	        'type' => 'color',
+	    );
+	
+	    /**
+	     * @var ValidatorInterface
+	     */
+	    protected $validator;
+	
+	    /**
+	     * Get validator
+	     *
+	     * @return ValidatorInterface
+	     */
+	    protected function getValidator()
+	    {
+	        if (null === $this->validator) {
+	            $this->validator = new RegexValidator('/^#[0-9a-fA-F]{6}$/');
+	        }
+	        return $this->validator;
+	    }
+	
+	    /**
+	     * Provide default input rules for this element
+	     *
+	     * Attaches an email validator.
+	     *
+	     * @return array
+	     */
+	    public function getInputSpecification()
+	    {
+	        return array(
+	            'name' => $this->getName(),
+	            'required' => true,
+	            'filters' => array(
+	                array('name' => 'Zend\Filter\StringTrim'),
+	                array('name' => 'Zend\Filter\StringToLower'),
+	            ),
+	            'validators' => array(
+	                $this->getValidator(),
+	            ),
+	        );
+	    }
+	}
 
 The above would hint to the input filter to create and attach an input named after the element, marking it as
-required, and giving it a ``StringTrim`` filter and an ``Email`` validator. Note that you can either rely on the
-input filter to create filters and validators, or directly instantiate them.
+required, and giving it a ``StringTrim`` and ``StringToLower`` filters and a ``Regex`` validator. Note that you can either rely on the input filter to create filters and validators, or directly instantiate them.
 
 For fieldsets, you do very similarly; the difference is that ``getInputFilterSpecification()`` must return
 configuration for an input filter.
@@ -538,7 +555,7 @@ additional user configuration!
 
 .. _zend.form.quick-start.binding:
 
-.. rubric:: Binding an object
+## Binding an object
 
 As noted in the intro, forms in Zend Framework bridge the domain model and the view layer. Let's see that in
 action.
@@ -546,8 +563,8 @@ action.
 When you ``bind()`` an object to the form, the following happens:
 
 - The composed ``Hydrator`` calls ``extract()`` on the object, and uses the values returned, if any, to populate
-  the ``value`` attributes of all elements.
-
+  the ``value`` attributes of all elements. If a form contains a fieldset that itself contains another fieldset, the form will recursively extract the values.
+  
 - When ``isValid()`` is called, if ``setData()`` has not been previously set, the form uses the composed
   ``Hydrator`` to extract values from the object, and uses those during validation.
 
@@ -607,7 +624,7 @@ implementing ``Zend\Stdlib\Hydrator\HydratorInterface``, which looks like this:
 
    namespace Zend\Stdlib\Hydrator;
 
-   interface Hydrator
+   interface HydratorInterface
    {
        /** @return array */
        public function extract($object);
@@ -616,7 +633,7 @@ implementing ``Zend\Stdlib\Hydrator\HydratorInterface``, which looks like this:
 
 .. _zend.form.quick-start.rendering:
 
-.. rubric:: Rendering
+## Rendering
 
 As noted previously, forms are meant to bridge the domain model and view layer. We've discussed the domain model
 binding, but what about the view?
@@ -765,10 +782,32 @@ you can pass an optional parameter to the ``FormRow`` view helper :
        echo $this->formRow($name, **'append'**);
    ?></div>
 
+### Taking advantage of HTML5 input attributes
+
+HTML5 brings a lot of exciting features, one of them being a simplified client form validations. Adding HTML5 attributes is simple as you just need to add specify the attributes. However, please note that adding those attributes does not automatically add Zend validators to the form's input filter. You still need to manually add them.
+
+.. code-block:: php
+   :linenos:
+
+   	$form->add(array(
+   		'name' => 'phoneNumber',
+   		'options' => array(
+   			'label' => 'Your phone number'
+   		),
+   		'attributes' => array(
+   			'type' => 'tel'
+   			'required' => 'required',
+   			'pattern'  => '^0[1-68]([-. ]?[0-9]{2}){4}$'
+   		)
+   	));
+
+View helpers will automatically render those attributes, and hence allowing modern browsers to perform automatic validation.
+
+> Note: although client validation is nice from a user experience point of view, it has to be used in addition with server validation, as client validation can be easily fooled.
 
 .. _zend.form.quick-start.partial:
 
-.. rubric:: Validation Groups
+## Validation Groups
 
 Sometimes you want to validate only a subset of form elements. As an example, let's say we're re-using our contact
 form over a web service; in this case, the ``Csrf``, ``Captcha``, and submit button elements are not of interest,
@@ -813,10 +852,11 @@ When your form contains nested fieldsets, you can use an array notation to valid
        // "profile" fieldset
        $data = $form->getData();
    }
+   
 
 .. _zend.form.quick-start.annotations:
 
-.. rubric:: Using Annotations
+## Using Annotations
 
 Creating a complete forms solution can often be tedious: you'll create some domain model object, an input filter
 for validating it, a form object for providing a representation for it, and potentially a hydrator for mapping the

--- a/docs/languages/en/modules/zend.form.view.helper.form-multicheckbox.rst
+++ b/docs/languages/en/modules/zend.form.view.helper.form-multicheckbox.rst
@@ -1,0 +1,45 @@
+.. _zend.form.view.helper.form-multicheckbox:
+
+FormMultiCheckbox
+^^^^^^^^^^^^^^^^^
+
+The ``FormMultiCheckbox`` view helper can be used to render a group ``<input type="checkbox">`` HTML
+form inputs. It is meant to work with the :ref:`Zend\\Form\\Element\\MultiCheckbox <zend.form.element.multicheckbox>`
+element, which provides a default input specification for validating the a multi checkbox.
+
+``FormMultiCheckbox`` extends from :ref:`Zend\\Form\\View\\Helper\\FormInput <zend.form.view.helper.form-input.methods>`.
+
+.. _zend.form.view.helper.form-multicheckbox.usage:
+
+Basic usage:
+
+.. code-block:: php
+   :linenos:
+
+   use Zend\Form\Element;
+
+   $element = new Element\MultiCheckbox('my-multicheckbox');
+   $element->setValueOptions(array(
+      '0' => 'Apple',
+      '1' => 'Orange',
+      '2' => 'Lemon',
+   ));
+
+   // Within your view...
+
+   /**
+    * Example #1: using the default label placement
+    */
+   echo $this->formMultiCheckbox($element);
+   // <label><input type="checkbox" name="my-multicheckbox[]" value="0">Apple</label>
+   // <label><input type="checkbox" name="my-multicheckbox[]" value="1">Orange</label>
+   // <label><input type="checkbox" name="my-multicheckbox[]" value="2">Lemon</label>
+   
+   /**
+    * Example #2: using the prepend label placement
+    */
+   echo $this->formMultiCheckbox($element, 'prepend');
+   // <label>Apple<input type="checkbox" name="my-multicheckbox[]" value="0"></label>
+   // <label>Orange<input type="checkbox" name="my-multicheckbox[]" value="1"></label>
+   // <label>Lemon<input type="checkbox" name="my-multicheckbox[]" value="2"></label>
+

--- a/docs/languages/en/modules/zend.form.view.helper.form-radio.rst
+++ b/docs/languages/en/modules/zend.form.view.helper.form-radio.rst
@@ -1,0 +1,42 @@
+.. _zend.form.view.helper.form-radio:
+
+FormRadio
+^^^^^^^^^
+
+The ``FormRadio`` view helper can be used to render a group ``<input type="radio">`` HTML
+form inputs. It is meant to work with the :ref:`Zend\\Form\\Element\\Radio <zend.form.element.radio>`
+element, which provides a default input specification for validating a radio.
+
+``FormRadio`` extends from :ref:`Zend\\Form\\View\\Helper\\FormMultiCheckbox <zend.form.view.helper.form-multicheckbox.methods>`.
+
+.. _zend.form.view.helper.form-radio.usage:
+
+Basic usage:
+
+.. code-block:: php
+   :linenos:
+
+   use Zend\Form\Element;
+
+   $element = new Element\Radio('gender');
+   $element->setValueOptions(array(
+      '0' => 'Male',
+      '1' => 'Female',
+   ));
+
+   // Within your view...
+
+   /**
+    * Example #1: using the default label placement
+    */
+   echo $this->formRadio($element);
+   // <label><input type="radio" name="gender[]" value="0">Male</label>
+   // <label><input type="radio" name="gender[]" value="1">Female</label>
+   
+   /**
+    * Example #2: using the prepend label placement
+    */
+   echo $this->formRadio($element, 'prepend');
+   // <label>Male<input type="checkbox" name="gender[]" value="0"></label>
+   // <label>Female<input type="checkbox" name="gender[]" value="1"></label>
+

--- a/docs/languages/en/modules/zend.form.view.helper.form-select.rst
+++ b/docs/languages/en/modules/zend.form.view.helper.form-select.rst
@@ -1,0 +1,35 @@
+.. _zend.form.view.helper.form-select:
+
+FormSelect
+^^^^^^^^^^
+
+The ``FormSelect`` view helper can be used to render a group ``<input type="select">`` HTML
+form input. It is meant to work with the :ref:`Zend\\Form\\Element\\Select <zend.form.element.select>`
+element, which provides a default input specification for validating a select.
+
+``FormSelect`` extends from :ref:`Zend\\Form\\View\\Helper\\FormInput <zend.form.view.helper.form-input.methods>`.
+
+.. _zend.form.view.helper.form-select.usage:
+
+Basic usage:
+
+.. code-block:: php
+   :linenos:
+
+   use Zend\Form\Element;
+
+   $element = new Element\Select('language');
+   $element->setValueOptions(array(
+      '0' => 'French',
+      '1' => 'English',
+      '2' => 'Japanese',
+      '3' => 'Chinese'
+   ));
+
+   // Within your view...
+
+   /**
+    * Example
+    */
+   echo $this->formSelect($element);
+

--- a/docs/languages/en/modules/zend.form.view.helpers.rst
+++ b/docs/languages/en/modules/zend.form.view.helpers.rst
@@ -26,6 +26,9 @@ Standard Helpers
 .. include:: zend.form.view.helper.form-image.rst
 .. include:: zend.form.view.helper.form-input.rst
 .. include:: zend.form.view.helper.form-label.rst
+.. include:: zend.form.view.helper.form-multicheckbox.rst
+.. include:: zend.form.view.helper.form-radio.rst
+.. include:: zend.form.view.helper.form-select.rst
 .. include:: zend.form.view.helper.abstract-helper.rst
 
 HTML5 Helpers


### PR DESCRIPTION
This PR adds the missing element, add an exemple for every element using the array notation, and update the QuickStart section (adding a note about HTM5 validation too).

The documentation about MonthSelect and DateSelect (that will be added in 2.1), I'll wait for them to be merged before writing it.

I think the documentation is quite complete. If you need something specific to be explained, please stay me tuned. It may be useful to add a new "Examples" section, where we could write some often used forms (login form, user with a profile form, address with a city form...).

What do you think ?
