### PR TITLE
Fix references to path of AlbumController file

### DIFF
--- a/docs/languages/en/user-guide/forms-and-actions.rst
+++ b/docs/languages/en/user-guide/forms-and-actions.rst
@@ -314,7 +314,7 @@ This time we use ``editAction()`` in the ``AlbumController``:
 
 .. code-block:: php
 
-    // module/Album/src/Album/AlbumController.php:
+    // module/Album/src/Album/Controller/AlbumController.php:
     //...
 
         // Add content to this method:
@@ -468,7 +468,7 @@ Let’s start with the action code in ``AlbumController::deleteAction()``:
 
 .. code-block:: php
 
-    // module/Album/src/Album/AlbumController.php:
+    // module/Album/src/Album/Controller/AlbumController.php:
     //...
         // Add content to the following method:
         public function deleteAction()


### PR DESCRIPTION
In these sections
- Editing an Album
- Deleting an Album

The comment identifying the file the snippet belonged to was incorrect: (`module/Album/src/Album/AlbumController.php` instead of `module/Album/src/Album/Controller/AlbumController.php`)
