### PR TITLE
Remove ">" prefix from Fatal Error example text

### DIFF
--- a/docs/languages/en/ref/installation.rst
+++ b/docs/languages/en/ref/installation.rst
@@ -20,9 +20,9 @@ found in the library folder. There are `several ways to achieve this`_.
 
 Failing to find a Zend Framework 2 installation, the following error occurs::
 
->Fatal error: Uncaught exception 'RuntimeException' with message
->'Unable to load ZF2. Run `php composer.phar install` or define 
->a ZF2_PATH environment variable.'
+ Fatal error: Uncaught exception 'RuntimeException' with message
+ 'Unable to load ZF2. Run `php composer.phar install` or define 
+ a ZF2_PATH environment variable.'
 
 To fix that, you can add the Zend Framework's library path to the *PHP* `include_path`_.
 Also, you should set an environment path named 'ZF2_PATH' in httpd.conf (or equivalent).


### PR DESCRIPTION
Currently renders like so:

![](http://s.lundrigan.ca/8a96fe.png)
