### PR TITLE
Added zend.cache.backend to en TOC

### DIFF
--- a/docs/languages/en/index.rst
+++ b/docs/languages/en/index.rst
@@ -35,6 +35,7 @@
    modules/zend.cache.storage.adapter
    modules/zend.cache.storage.capabilities
    modules/zend.cache.storage.plugin
+   modules/zend.cache.backend
    modules/zend.cache.pattern
    modules/zend.captcha.intro
    modules/zend.captcha.operation


### PR DESCRIPTION
When compiling documentation:

```
make html
```

 I received this Python traceback:

```
# Sphinx version: 1.1.3
# Python version: 2.7.3
# Docutils version: 0.8.1 release
# Jinja2 version: 2.6
Traceback (most recent call last):
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/cmdline.py", line 189, in main
    app.build(force_all, filenames)
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/application.py", line 204, in build
    self.builder.build_update()
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/builders/__init__.py", line 196, in build_update
    'out of date' % len(to_build))
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/builders/__init__.py", line 252, in build
    self.write(docnames, list(updated_docnames), method)
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/builders/__init__.py", line 292, in write
    self.write_doc(docname, doctree)
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/builders/html.py", line 424, in write_doc
    ctx = self.get_doc_context(docname, body, metatags)
  File "/usr/local/python27/lib/python2.7/site-packages/Sphinx-1.1.3-py2.7.egg/sphinx/builders/html.py", line 407, in get_doc_context
    display_toc = (self.env.toc_num_entries[docname] > 1),
KeyError: 'modules/zend.cache.backends'
```

The attached change (adding `modules/zend.cache.backends` to the TOC) fixed it for me.
