### PR TITLE
Replace zf with public/index.php in docs.

### DIFF
--- a/docs/languages/en/modules/zend.console.controllers.rst
+++ b/docs/languages/en/modules/zend.console.controllers.rst
@@ -65,9 +65,9 @@ This route will match commands such as:
 
 .. code-block:: bash
 
-    > zf show users
-    > zf show all users
-    > zf show disabled users
+    > php public/index.php show users
+    > php public/index.php show all users
+    > php public/index.php show disabled users
 
 This route points to the method ``Application\IndexController::showUsersAction()``.
 


### PR DESCRIPTION
zf doesn't exist in zf2, the console routers are invoked through the normal router (public/index.php)
