### PR TITLE
Partially fix/improve module manager docs

### DIFF
--- a/docs/languages/en/modules/zend.module-manager.intro.rst
+++ b/docs/languages/en/modules/zend.module-manager.intro.rst
@@ -18,8 +18,8 @@ possibilities are endless.
 
 The module system is made up of the following:
 
-- **The Module Autoloader** - ``Zend\Loader\ModuleAutoloader`` is a specialized autoloader that is responsible for
-  the locating and loading of modules' ``Module`` classes from a variety of sources.
+- :ref:`The Module Autoloader <zend.loader.module-autoloader>` - ``Zend\Loader\ModuleAutoloader`` is a specialized 
+  autoloader that is responsible for the locating and loading of modules' ``Module`` classes from a variety of sources.
 
 - :ref:`The Module Manager <zend.module-manager.module-manager>` - ``Zend\ModuleManager\ModuleManager`` simply takes
   an array of module names and fires a sequence of events for each one, allowing the behavior of the module system
@@ -53,12 +53,12 @@ The recommended structure of a typical MVC-oriented ZF2 module is as follows:
        src/
            <module_namespace>/
                <code files>
-       tests/
+       test/
            phpunit.xml
            bootstrap.php
            <module_namespace>/
                <test code files>
-       views/
+       view/
            <dir-named-after-module-namespace>/
                <dir-named-after-a-controller>/
                    <.phtml files>

--- a/docs/languages/en/modules/zend.module-manager.module-class.rst
+++ b/docs/languages/en/modules/zend.module-manager.module-class.rst
@@ -151,4 +151,8 @@ event, once *$application->bootstrap()* is called.
        }
    }
 
+.. note::
 
+   The ``onBootstrap()`` method is called for **every** module implementing this feature,
+   on **every** page request, and should **only** be used for performing **lightweight** tasks such as registering
+   event listeners.

--- a/docs/languages/en/modules/zend.module-manager.module-manager.rst
+++ b/docs/languages/en/modules/zend.module-manager.module-manager.rst
@@ -63,8 +63,8 @@ By default, Zend Framework provides several useful module manager listeners.
    to ``Zend\Loader\AutoloaderFactory``.
 
 **Zend\\ModuleManager\\Listener\\ConfigListener**
-   If a module class has a ``getConfig()`` method, this listener will call it and merge the returned array (or
-   ``Traversable`` object) into the main application configuration.
+   If a module class has a ``getConfig()`` method, or implements ``Zend\ModuleManager\Feature\ConfigProviderInterface``,
+   this listener will call it and merge the returned array (or ``Traversable`` object) into the main application configuration.
 
 **Zend\\ModuleManager\\Listener\\InitTrigger**
    If a module class either implements ``Zend\ModuleManager\Feature\InitProviderInterface``, or simply defines an


### PR DESCRIPTION
Hello!

Just don't have enough brain power any more to fix the ModuleManager documentation completely. Sorry.

Two things left to do, according to Evan's notes:
- Shared config key added under http://zf2.readthedocs.org/en/latest/modules/zend.module-manager.module-manager.html (see shared services on http://blog.evan.pro/introduction-to-the-zend-framework-2-servicemanager for explanation)
- Explanation that service configs which are just arrays of scalars should go into the config arrays under their config key ('services', 'view_helpers', 'controllers', 'controller_plugins' returned by getConfig(), but if you have any non-scalar (like closures for factories) it should go in the correct module method (getServiceConfig(), getViewHeleprConfig(), getControllerConfig(), etc).
