### PR TITLE
Add note about need for doctrine/common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ nbproject
 tmp/
 .DS_Store
 composer.lock
+.*.sw*
+.*.un~

--- a/docs/languages/en/modules/zend.form.quick-start.rst
+++ b/docs/languages/en/modules/zend.form.quick-start.rst
@@ -917,6 +917,23 @@ To use annotations, you simply include them in your class and/or property docblo
 resolved according to the import statements in your class; as such, you can make them as long or as short as you
 want depending on what you import.
 
+.. note::
+
+    Form annotations require ``Doctrine\\Common``, which contains an annotation
+    parsering engine. The simplest way to install ``Doctrine\\Common`` is if you
+    are using ``Composer``; simply update your ``composer.json`` and add the
+    following line to the ``require`` section:
+
+    .. code-block:: javascript
+
+       "doctrine/common": ">=2.1",
+
+    Then run ``php composer.phar update`` to install the dependency.
+
+    If you're not using ``Composer``, visit `the Doctrine project website
+    <http://www.doctrine-project.org/projects/common.html>`_ for more details on
+    installation.
+
 Here's a simple example.
 
 .. code-block:: php


### PR DESCRIPTION
- Added a note about the need for doctrine/common when using form annotations.
- Updated .gitignore to ignore vim swap and undo files
