### PR TITLE
Update docs/languages/en/modules/zend.service-manager.quick-start.rst

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.quick-start.rst
+++ b/docs/languages/en/modules/zend.service-manager.quick-start.rst
@@ -240,7 +240,7 @@ First, let's create a class that holds configuration.
    use Zend\ServiceManager\Config;
    use Zend\ServiceManager\ServiceManager;
 
-   class ServiceConfiguration extends Configuration
+   class ServiceConfiguration extends Config
    {
        /**
         * This is hard-coded for brevity.


### PR DESCRIPTION
"Configuration" doesn't seem to exist, also not listed in the "use" section.
