### PR TITLE
Form Collection js: replace all occurrences

### DIFF
--- a/docs/languages/en/modules/zend.form.collections.rst
+++ b/docs/languages/en/modules/zend.form.collections.rst
@@ -660,7 +660,7 @@ Here is the code:
         function add_category() {
             var currentCount = $('form > fieldset > fieldset').length;
             var template = $('form > fieldset > span').data('template');
-            template = template.replace('__index__', currentCount);
+            template = template.replace(/__index__/g, currentCount);
     
             $('form > fieldset').append(template);
     


### PR DESCRIPTION
We need to use regex with `g` modifier, otherwise javascript will replace only the first occurence instead of all of them.
