### PR TITLE
add example with optional field in route

### DIFF
--- a/docs/languages/en/modules/zend.mvc.routing.rst
+++ b/docs/languages/en/modules/zend.mvc.routing.rst
@@ -677,7 +677,7 @@ how to set up routes in config files.
                     )
                 ),
                 // Segment route named "about"
-                'contact' => array(
+                'about' => array(
                     'type' => 'segment',
                     'options' => array(
                         'route' => '/about',


### PR DESCRIPTION
The added example which shows that optional fields have to be filled when using child routes.

There was a discussion on zfforum.de about optionals fields in a parent route result in unsuspected URLs. The thread is located at http://www.zfforum.de/zf2-mvc/9617-falsche-routen-ich-krieg-nen-knall.html

From my understanding, you have to fill the optional fields when using the child route so that the router could match the exact routes. If my example is wrong, please correct it :) That's my first patch for ZF2 documentaion so feedback is highly appreciated!
