### PR TITLE
Update docs/languages/en/modules/zend.mvc.controllers.rst

### DIFF
--- a/docs/languages/en/modules/zend.mvc.controllers.rst
+++ b/docs/languages/en/modules/zend.mvc.controllers.rst
@@ -52,7 +52,7 @@ A controller that has the ``MvcEvent`` injected, then, can retrieve or inject th
    $matches = $this->getEvent()->getRouteMatch();
    $id      = $matches->getParam('id', false);
    if (!$id) {
-       $this->getResponse();
+       $response = $this->getResponse();
        $response->setStatusCode(500);
        $this->getEvent()->setResult('Invalid identifier; cannot complete request');
        return;


### PR DESCRIPTION
Missing $response variables on example 'InjectApplicationEvent'
