### PR TITLE
zend text table example should result two rows

### DIFF
--- a/docs/languages/en/modules/zend.text.table.rst
+++ b/docs/languages/en/modules/zend.text.table.rst
@@ -99,6 +99,7 @@ This will result in the following output:
 
    ┌──────────┬────────────────────┐
    │Zend      │Framework           │
+   |──────────|────────────────────|
+   │Zend      │Framework           │
    └──────────┴────────────────────┘
-
 


### PR DESCRIPTION
it's to illustrate the same result with appendRow() and verbose appendRow($row)
