### PR TITLE
fix link rbac.methods

### DIFF
--- a/docs/languages/en/index.rst
+++ b/docs/languages/en/index.rst
@@ -168,7 +168,7 @@
    modules/zend.permissions.acl.refining
    modules/zend.permissions.acl.advanced
    modules/zend.permissions.rbac.intro
-   modules/zend.permissions.rbac.quick-start
+   modules/zend.permissions.rbac.methods
    modules/zend.permissions.rbac.examples
    modules/zend.server
    modules/zend.server.reflection


### PR DESCRIPTION
because modules/zend.permissions.rbac.quick-start is removed.
