### PR TITLE
fix incorrect DB driver charset configuration

### DIFF
--- a/docs/languages/en/modules/zend.db.adapter.rst
+++ b/docs/languages/en/modules/zend.db.adapter.rst
@@ -42,7 +42,7 @@ key-value pairs that should be in configuration array.
    +------------+----------------------+-------------------------------------------------------------+
    |port        |not generally required|the port to connect to (if applicable)                       |
    +------------+----------------------+-------------------------------------------------------------+
-   |characterset|not generally required|the character set to use                                     |
+   |charset     |not generally required|the character set to use                                     |
    +------------+----------------------+-------------------------------------------------------------+
 
 .. note:: 


### PR DESCRIPTION
We must use "charset" instead "characterset" to set preferred charset in DB driver config.
- mysqli - https://github.com/zendframework/zf2/blob/master/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php#L179
- PDO - https://github.com/zendframework/zf2/blob/master/library/Zend/Db/Adapter/Driver/Pdo/Connection.php#L190
