### PR TITLE
Update docs/languages/en/modules/zend.db.table-gateway.rst

### DIFF
--- a/docs/languages/en/modules/zend.db.table-gateway.rst
+++ b/docs/languages/en/modules/zend.db.table-gateway.rst
@@ -137,7 +137,7 @@ There are a number of features built-in and shipped with Zend\\Db:
   .. code-block:: php
      :linenos:
 
-     class MyTableGateway extends <classname>AbstractTableGateway</classname>
+     class MyTableGateway extends AbstractTableGateway
      {
      	public function __construct()
      	{


### PR DESCRIPTION
removed <classname> tag in one code-block. <classname> is displaying to the users. It is not being interpreted as a markup.
