### PR TITLE
Update docs/languages/en/user-guide/unit-testing.rst

### DIFF
--- a/docs/languages/en/user-guide/unit-testing.rst
+++ b/docs/languages/en/user-guide/unit-testing.rst
@@ -209,6 +209,8 @@ the following contents:
 
     namespace ApplicationTest\Controller;
 
+    use ApplicationTest\Bootstrap;
+    use Zend\Mvc\Router\Http\TreeRouteStack as HttpRouter;
     use Application\Controller\IndexController;
     use Zend\Http\Request;
     use Zend\Http\Response;


### PR DESCRIPTION
I ran the example code on my ubuntu server zend server but when I ran the phpunit command I would get an Fatal Error because the class Bootstrap and HttpRouter could not be found.

By adding the two proposed use statements these errors where solved.
