### PR TITLE
Update docs/languages/en/modules/zend.db.adapter.rst

### DIFF
--- a/docs/languages/en/modules/zend.db.adapter.rst
+++ b/docs/languages/en/modules/zend.db.adapter.rst
@@ -344,6 +344,8 @@ interface.  Below is the ParameterContainer API:
 
 .. code-block:: php
 
+   namespace Zend\Db\Adapter;
+
     class ParameterContainer implements \Iterator, \ArrayAccess, \Countable {
         public function __construct(array $data = array())
         


### PR DESCRIPTION
Added a namespace.

This example $adapter->query('SELECT \* FROM `artist` WHERE `id` = ?', array(5)); appears incomplete if one compares it to its description below
