### PR TITLE
Moved Zend\View to Broken Documentation.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,6 @@ example section is present, but full documentation is missing.
 - Mail (Lead: Dolf Schimmel (Freeaqingme))
 - ServiceManager (Lead: Ralph Schindler (ralphschindler))
 - Stdlib (Lead: Matthew Weier O'Phinney (weierophinney))
-- View (Lead: Matthew Weier O'Phinney (weierophinney))
 
 Broken documentation
 --------------------
@@ -68,3 +67,4 @@ on the mailing list to determine what needs to be fixed.
 - Loader (Lead: Matthew Weier O'Phinney (weierophinney))
 - ModuleManager (Lead: Evan Coury (EvanDotPro))
 - Mvc (Lead: Matthew Weier O'Phinney (weierophinney))
+- View (Lead: Matthew Weier O'Phinney (weierophinney))


### PR DESCRIPTION
I believe at least the part about layouts in the quick start is completely broken.
For example, it explains usage of a non-existing 'Zend\Mvc\View\DefaultRenderingStrategy'.
Also, it encourages use of Zend\Di.
