### PR TITLE
Added missing getServiceLocator() method

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.quick-start.rst
+++ b/docs/languages/en/modules/zend.service-manager.quick-start.rst
@@ -266,7 +266,7 @@ any class implementing ``Zend\ServiceManager\ServiceLocatorAwareInterface``. A s
    use Zend\Stdlib\RequestInterface as Request;
    use Zend\Stdlib\ResponseInterface as Response;
 
-   class BareController implements 
+   class BareController implements
        Dispatchable,
        ServiceLocatorAwareInterface
    {


### PR DESCRIPTION
When implementing the ServiceLocatorAwareInterface the getServiceLocator() must be implemented. 

The class signature for implementing interfaces was fixed too, to follow the coding standards:
http://framework.zend.com/wiki/display/ZFDEV2/Coding+Standards#CodingStandards-ClassDeclaration
