### PR TITLE
Fixed an error in using fopen() with only one parameter, where a second ...

### DIFF
--- a/docs/languages/en/modules/zend.mail.message.rst
+++ b/docs/languages/en/modules/zend.mail.message.rst
@@ -110,7 +110,7 @@ automatically set a "MIME-Version" header, as well as an appropriate "Content-Ty
    $html = new MimePart($htmlMarkup);
    $html->type = "text/html";
 
-   $image = new MimePart(fopen($pathToImage));
+   $image = new MimePart(fopen($pathToImage, 'r'));
    $image->type = "image/jpeg";
 
    $body = new MimeMessage();


### PR DESCRIPTION
...parameter is necessary. fopen() expects at least two parameters, the second one being the mode, which specifies the type of access to the stream. 'r' is sufficient enough for our purposes here.
