### PR TITLE
Better documentation of cache storages

### DIFF
--- a/docs/languages/en/modules/zend.cache.pattern.callback-cache.rst
+++ b/docs/languages/en/modules/zend.cache.pattern.callback-cache.rst
@@ -54,49 +54,41 @@ Configuration Options
 Available Methods
 -----------------
 
-.. _zend.cache.pattern.callback-cache.methods.call:
+.. function:: call(callable $callback, array $args = array())
+   :noindex:
 
-**call**
-   ``call(callable $callback, array $args = array())``
+   Call the specified callback or get the result from cache.
 
-   Call the specified callback or get the result from cache
+   :rtype: mixed
 
-   Returns the result
+.. function:: __call(string $function, array $args)
+   :noindex:
 
-.. _zend.cache.pattern.callback-cache.methods.__call:
+   Function call handler.
 
-**__call**
-   ``__call(string $function, array $args)``
+   :rtype: mixed
 
-   Function call handler
-
-   Returns the result
-
-**generateKey**
-   ``generateKey(callable $callback, array $args = array())``
+.. function:: generateKey(callable $callback, array $args = array())
+   :noindex:
 
    Generate a unique key in base of a key representing the callback part
    and a key representing the arguments part.
 
-   Returns the key
+   :rtype: string
 
-.. _zend.cache.pattern.callback-cache.methods.set-options:
+.. function:: setOptions(Zend\\Cache\\Pattern\\PatternOptions $options)
+   :noindex:
 
-**setOptions**
-   ``setOptions(Zend\Cache\Pattern\PatternOptions $options)``
+   Set pattern options.
 
-   Set pattern options
+   :rtype: Zend\\Cache\\Pattern\\CallbackCache
 
-   Returns Zend\\Cache\\Pattern\\CallbackCache
+.. function:: getOptions()
+   :noindex:
 
-.. _zend.cache.pattern.callback-cache.methods.get-options:
+   Get all pattern options.
 
-**getOptions**
-   ``getOptions()``
-
-   Get all pattern options
-
-   Returns ``PatternOptions`` instance.
+   :rtype: Zend\\Cache\\Pattern\\PatternOptions
 
 .. _zend.cache.pattern.pattern-factory.examples:
 

--- a/docs/languages/en/modules/zend.cache.pattern.capture-cache.rst
+++ b/docs/languages/en/modules/zend.cache.pattern.capture-cache.rst
@@ -69,69 +69,61 @@ Configuration Options
 Available Methods
 -----------------
 
-.. _zend.cache.pattern.capture-cache.methods.start:
+.. function:: start(string|null $pageId = null)
+   :noindex:
 
-**start**
-   ``start(string|null $pageId = null)``
+   Start capturing output.
 
-   Start capturing output
+   :rtype: void
 
-   Returns void
+.. function:: set(string $content, string|null $pageId = null)
+   :noindex:
 
-.. _zend.cache.pattern.capture-cache.methods.set:
+   Write content to page identity.
 
-**set**
-   ``set(string $content, string|null $pageId = null)``
+   :rtype: void
 
-   Write content to page identity
+.. function:: get(string|null $pageId = null)
+   :noindex:
 
-   Returns void
+   Get content of an already cached page.
 
-**get**
-   ``get(string|null $pageId = null)``
+   :rtype: string|false
 
-   Get content of an already cached page
+.. function:: has(string|null $pageId = null)
+   :noindex:
 
-   Returns string|false
+   Check if a page has been created.
 
-**has**
-   ``has(string|null $pageId = null)``
+   :rtype: boolean
 
-   Check if a page has been created
+.. function:: remove(string|null $pageId = null)
+   :noindex:
 
-   Returns boolean
+   Remove a page.
 
-**remove**
-   ``remove(string|null $pageId = null)``
+   :rtype: boolean
 
-   Remove a page
+.. function:: clearByGlob(string $pattern = '**')
+   :noindex:
 
-   Returns boolean
+   Clear pages matching glob pattern.
 
-**clearByGlob**
-   ``clearByGlob(string $pattern = '**')``
+   :rtype: void
 
-   Clear pages matching glob pattern
+.. function:: setOptions(Zend\\Cache\\Pattern\\PatternOptions $options)
+   :noindex:
 
-   Returns void
+   Set pattern options.
 
-.. _zend.cache.pattern.capture-cache.methods.set-options:
+   :rtype: Zend\\Cache\\Pattern\\OutputCache
 
-**setOptions**
-   ``setOptions(Zend\Cache\Pattern\PatternOptions $options)``
+.. function:: getOptions()
+   :noindex:
 
-   Set pattern options
+   Get all pattern options.
 
-   Returns Zend\\Cache\\Pattern\\OutputCache
-
-.. _zend.cache.pattern.capture-cache.methods.get-options:
-
-**getOptions**
-   ``getOptions()``
-
-   Get all pattern options
-
-   Returns ``PatternOptions`` instance.
+   :rtype: Zend\\Cache\\Pattern\\PatternOptions
 
 .. _zend.cache.pattern.pattern-factory.examples:
 

--- a/docs/languages/en/modules/zend.cache.pattern.class-cache.rst
+++ b/docs/languages/en/modules/zend.cache.pattern.class-cache.rst
@@ -55,73 +55,69 @@ Configuration Options
 Available Methods
 -----------------
 
-.. _zend.cache.pattern.class-cache.methods.call:
+.. function:: call(string $method, array $args = array())
+   :noindex:
 
-**call**
-   ``call(string $method, array $args = array())``
+    Call the specified method of the configured class.
 
-   Call the specified method of the configured class
+   :rtype: mixed
 
-   Returns the result
+.. function:: __call(string $method, array $args)
+   :noindex:
 
-.. _zend.cache.pattern.class-cache.methods.__call:
+    Call the specified method of the configured class.
 
-**__call**
-   ``__call(string $method, array $args)``
+   :rtype: mixed
 
-   Call the specified method of the configured class
+.. function:: __set(string $name, mixed $value)
+   :noindex:
 
-   Returns the result
+    Set a static property of the configured class.
 
-**__set**
+   :rtype: void
 
-    ``__set(string $name, mixed $value)``
-    
-    Set a static property of the configured class
+.. function:: __get(string $name)
+   :noindex:
 
-**__get**
+    Get a static property of the configured class.
 
-    ``__get(string $name)``
-    
-    Get a static property of the configured class
+   :rtype: mixed
 
-**__isset**
+.. function:: __isset(string $name)
+   :noindex:
 
-    ``__isset(string $name)``
+    Checks if a static property of the configured class exists.
 
-    Checks if a static property of the configured class exists
+   :rtype: boolean
 
-**__unset**
+.. function:: __unset(string $name)
+   :noindex:
 
-    ``__unset(string $name)``
+    Unset a static property of the configured class.
 
-    Unset a static property of the configured class
+   :rtype: void
 
-**generateKey**
-   ``generateKey(string $method, array $args = array())``
+.. function:: generateKey(string $method, array $args = array())
+   :noindex:
 
    Generate a unique key in base of a key representing the callback part
    and a key representing the arguments part.
 
-   Returns the key
+   :rtype: string
 
-.. _zend.cache.pattern.class-cache.methods.set-options:
+.. function:: setOptions(Zend\\Cache\\Pattern\\PatternOptions $options)
+   :noindex:
 
-**setOptions**
-   ``setOptions(Zend\Cache\Pattern\PatternOptions $options)``
+   Set pattern options.
 
-   Set pattern options
+   :rtype: Zend\\Cache\\Pattern\\ClassCache
 
-   Returns Zend\\Cache\\Pattern\\ClassCache
+.. function:: getOptions()
+   :noindex:
 
-.. _zend.cache.pattern.class-cache.methods.get-options:
+   Get all pattern options.
 
-**getOptions**
-   ``getOptions()``
-
-   Get all pattern options
-
-   Returns ``PatternOptions`` instance.
+   :rtype: Zend\\Cache\\Pattern\\PatternOptions
 
 .. _zend.cache.pattern.pattern-factory.examples:
 

--- a/docs/languages/en/modules/zend.cache.pattern.object-cache.rst
+++ b/docs/languages/en/modules/zend.cache.pattern.object-cache.rst
@@ -60,73 +60,69 @@ Configuration Options
 Available Methods
 -----------------
 
-.. _zend.cache.pattern.object-cache.methods.call:
+.. function:: call(string $method, array $args = array())
+   :noindex:
 
-**call**
-   ``call(string $method, array $args = array())``
+    Call the specified method of the configured object.
 
-   Call the specified method of the configured object
+   :rtype: mixed
 
-   Returns the result
+.. function:: __call(string $method, array $args)
+   :noindex:
 
-.. _zend.cache.pattern.object-cache.methods.__call:
+    Call the specified method of the configured object.
 
-**__call**
-   ``__call(string $method, array $args)``
+   :rtype: mixed
 
-   Call the specified method of the configured object
+.. function:: __set(string $name, mixed $value)
+   :noindex:
 
-   Returns the result
+    Set a property of the configured object.
 
-**__set**
+   :rtype: void
 
-    ``__set(string $name, mixed $value)``
-    
-    Set a property of the configured object
+.. function:: __get(string $name)
+   :noindex:
 
-**__get**
+    Get a property of the configured object.
 
-    ``__get(string $name)``
-    
-    Get a property of the configured object
+   :rtype: mixed
 
-**__isset**
+.. function:: __isset(string $name)
+   :noindex:
 
-    ``__isset(string $name)``
+    Checks if static property of the configured object exists.
 
-    Checks if static property of the configured object exists
+   :rtype: boolean
 
-**__unset**
+.. function:: __unset(string $name)
+   :noindex:
 
-    ``__unset(string $name)``
+    Unset a property of the configured object.
 
-    Unset a property of the configured object
+   :rtype: void
 
-**generateKey**
-   ``generateKey(string $method, array $args = array())``
+.. function:: generateKey(string $method, array $args = array())
+   :noindex:
 
    Generate a unique key in base of a key representing the callback part
    and a key representing the arguments part.
 
-   Returns the key
+   :rtype: string
 
-.. _zend.cache.pattern.object-cache.methods.set-options:
+.. function:: setOptions(Zend\\Cache\\Pattern\\PatternOptions $options)
+   :noindex:
 
-**setOptions**
-   ``setOptions(Zend\Cache\Pattern\PatternOptions $options)``
+   Set pattern options.
 
-   Set pattern options
+   :rtype: Zend\\Cache\\Pattern\\ObjectCache
 
-   Returns Zend\\Cache\\Pattern\\ObjectCache
+.. function:: getOptions()
+   :noindex:
 
-.. _zend.cache.pattern.object-cache.methods.get-options:
+   Get all pattern options.
 
-**getOptions**
-   ``getOptions()``
-
-   Get all pattern options
-
-   Returns ``PatternOptions`` instance.
+   :rtype: Zend\\Cache\\Pattern\\PatternOptions
 
 .. _zend.cache.pattern.pattern-factory.examples:
 

--- a/docs/languages/en/modules/zend.cache.pattern.output-cache.rst
+++ b/docs/languages/en/modules/zend.cache.pattern.output-cache.rst
@@ -42,43 +42,35 @@ Configuration Options
 Available Methods
 -----------------
 
-.. _zend.cache.pattern.output-cache.methods.start:
+.. function:: start(string $key)
+   :noindex:
 
-**start**
-   ``start(string $key)``
+   If there is a cached item with the given key display it's data and return ``true``
+   else start buffering output until ``end()`` is called or the script ends and return ``false``.
 
-   If there is a cached item with the given key display it's data and return true
-   else start buffering output until end() is called or the script ends and return false.
+   :rtype: boolean
 
-   Returns boolean
+.. function:: end()
+   :noindex:
 
-.. _zend.cache.pattern.output-cache.methods.end:
-
-**end**
-   ``end()``
-
-   Stops buffering output, write buffered data to cache using the given key on start()
+   Stops buffering output, write buffered data to cache using the given key on ``start()``
    and displays the buffer.
 
-   Returns boolean
+   :rtype: boolean
 
-.. _zend.cache.pattern.output-cache.methods.set-options:
+.. function:: setOptions(Zend\\Cache\\Pattern\\PatternOptions $options)
+   :noindex:
 
-**setOptions**
-   ``setOptions(Zend\Cache\Pattern\PatternOptions $options)``
+   Set pattern options.
 
-   Set pattern options
+   :rtype: Zend\\Cache\\Pattern\\OutputCache
 
-   Returns Zend\\Cache\\Pattern\\OutputCache
+.. function:: getOptions()
+   :noindex:
 
-.. _zend.cache.pattern.output-cache.methods.get-options:
+   Get all pattern options.
 
-**getOptions**
-   ``getOptions()``
-
-   Get all pattern options
-
-   Returns ``PatternOptions`` instance.
+   :rtype: Zend\\Cache\\Pattern\\PatternOptions
 
 .. _zend.cache.pattern.pattern-factory.examples:
 

--- a/docs/languages/en/modules/zend.cache.pattern.rst
+++ b/docs/languages/en/modules/zend.cache.pattern.rst
@@ -57,18 +57,16 @@ Please read documentation of specific patterns to get more information.
 
 .. _zend.cache.pattern.methods.set-options:
 
-**setOptions**
-   ``setOptions(Zend\Cache\Pattern\PatternOptions $options)``
+.. function:: setOptions(Zend\\Cache\\Pattern\\PatternOptions $options)
+   :noindex:
 
-   Set pattern options
+   Set pattern options.
 
-   Returns Zend\\Cache\\Pattern
+   :rtype: Zend\\Cache\\Pattern\\PatternInterface
 
-.. _zend.cache.pattern.methods.get-options:
+.. function:: getOptions()
+   :noindex:
 
-**getOptions**
-   ``getOptions()``
+   Get all pattern options.
 
-   Get all pattern options
-
-   Returns ``PatternOptions`` instance.
+   :rtype: Zend\\Cache\\Pattern\\PatternOptions

--- a/docs/languages/en/modules/zend.cache.storage.adapter.rst
+++ b/docs/languages/en/modules/zend.cache.storage.adapter.rst
@@ -110,206 +110,164 @@ The StorageInterface
 
 The ``Zend\Cache\Storage\StorageInterface`` is the basic interface implemented by all storage adapters.
 
-.. _zend.cache.storage.adapter.methods.get-item:
-
-**getItem**
-   ``getItem(string $key, boolean & $success = null, mixed & $casToken = null)``
+.. function:: getItem(string $key, boolean & $success = null, mixed & $casToken = null)
+   :noindex:
 
    Load an item with the given $key.
-
+   
    If item exists set parameter $success to ``true``, set parameter $casToken and returns ``mixed`` value of item.
-
+   
    If item can't load set parameter $success to ``false`` and returns ``null``.
 
-.. _zend.cache.storage.adapter.methods.get-items:
+   :rtype: mixed
 
-**getItems**
-   ``getItems(array $keys)``
+.. function:: getItems(array $keys)
+   :noindex:
 
-   Load all items given by $keys.
+   Load all items given by $keys returning key-value pairs.
 
-   Returns ``array`` of key-value pairs of available items.
+   :rtype: array
 
-.. _zend.cache.storage.adapter.methods.has-item:
-
-**hasItem**
-   ``hasItem(string $key)``
+.. function:: hasItem(string $key)
+   :noindex:
 
    Test if an item exists.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.has-items:
-
-**hasItems**
-   ``hasItems(array $keys)``
+.. function:: hasItems(array $keys)
+   :noindex:
 
    Test multiple items.
 
-   Returns ``array``
+   :rtype: string[]
 
-.. _zend.cache.storage.adapter.methods.get-metadata:
-
-**getMetadata**
-   ``getMetadata(string $key)``
+.. function:: getMetadata(string $key)
+   :noindex:
 
    Get metadata of an item.
 
-   Returns ``array`` ``boolean``
+   :rtype: array|boolean
 
-.. _zend.cache.storage.adapter.methods.get-metadatas:
-
-**getMetadatas**
-   ``getMetadatas(array $keys)``
+.. function:: getMetadatas(array $keys)
+   :noindex:
 
    Get multiple metadata.
 
-   Returns ``array``
+   :rtype: array
 
-.. _zend.cache.storage.adapter.methods.set-item:
-
-**setItem**
-   ``setItem(string $key, mixed $value)``
+.. function:: setItem(string $key, mixed $value)
+   :noindex:
 
    Store an item.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.set-items:
-
-**setItems**
-   ``setItems(array $keyValuePairs)``
+.. function:: setItems(array $keyValuePairs)
+   :noindex:
 
    Store multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.add-item:
-
-**addItem**
-   ``addItem(string $key, mixed $value)``
+.. function:: addItem(string $key, mixed $value)
+   :noindex:
 
    Add an item.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.add-items:
-
-**addItems**
-   ``addItems(array $keyValuePairs)``
+.. function:: addItems(array $keyValuePairs)
+   :noindex:
 
    Add multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.replace-item:
-
-**replaceItem**
-   ``replaceItem(string $key, mixed $value)``
+.. function:: replaceItem(string $key, mixed $value)
+   :noindex:
 
    Replace an item.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.replace-items:
-
-**replaceItems**
-   ``replaceItems(array $keyValuePairs)``
+.. function:: replaceItems(array $keyValuePairs)
+   :noindex:
 
    Replace multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.check-and-set-item:
+.. function:: checkAndSetItem(mixed $token, string $key, mixed $value)
+   :noindex:
 
-**checkAndSetItem**
-   ``checkAndSetItem(mixed $token, string $key, mixed $value)``
+   Set item only if token matches. It uses the token received from ``getItem()``
+   to check if the item has changed before overwriting it.
 
-   Set item only if token matches.
-   It uses the token received from ``getItem()`` to check if the item has changed before overwriting it.
+   :rtype: boolean
 
-   Returns ``boolean``
-
-.. _zend.cache.storage.adapter.methods.touch-item:
-
-**touchItem**
-   ``touchItem(string $key)``
+.. function:: touchItem(string $key)
+   :noindex:
 
    Reset lifetime of an item.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.touch-items:
-
-**touchItems**
-   ``touchItems(array $keys)``
+.. function:: touchItems(array $keys)
+   :noindex:
 
    Reset lifetime of multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.remove-item:
-
-**removeItem**
-   ``removeItem(string $key)``
+.. function:: removeItem(string $key)
+   :noindex:
 
    Remove an item.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.remove-items:
-
-**removeItems**
-   ``removeItems(array $keys)``
+.. function:: removeItems(array $keys)
+   :noindex:
 
    Remove multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.increment-item:
-
-**incrementItem**
-   ``incrementItem(string $key, int $value)``
+.. function:: incrementItem(string $key, int $value)
+   :noindex:
 
    Increment an item.
 
-   Returns ``integer`` ``boolean``
+   :rtype: integer|boolean
 
-.. _zend.cache.storage.adapter.methods.increment-items:
-
-**incrementItems**
-   ``incrementItems(array $keyValuePairs)``
+.. function:: incrementItems(array $keyValuePairs)
+   :noindex:
 
    Increment multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.decrement-item:
-
-**decrementItem**
-   ``decrementItem(string $key, int $value)``
+.. function:: decrementItem(string $key, int $value)
+   :noindex:
 
    Decrement an item.
 
-   Returns ``interger`` ``boolean``
+   :rtype: interger|boolean
 
-.. _zend.cache.storage.adapter.methods.decrement-items:
-
-**decrementItems**
-   ``decrementItems(array $keyValuePairs)``
+.. function:: decrementItems(array $keyValuePairs)
+   :noindex:
 
    Decrement multiple items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.get-capabilities:
-
-**getCapabilities**
-   ``getCapabilities()``
+.. function:: getCapabilities()
+   :noindex:
 
    Capabilities of this storage.
 
-   Returns ``Zend\Cache\Storage\Capabilities``
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
 .. _zend.cache.storage.adapter.methods-available-space-capable-interface:
 
@@ -319,14 +277,12 @@ The AvailableSpaceCapableInterface
 The ``Zend\Cache\Storage\AvailableSpaceCapableInterface`` implements a method
 to make it possible getting the current available space of the storage.
 
-.. _zend.cache.storage.adapter.methods.get-available-space:
-
-**getAvailableSpace**
-   ``getAvailableSpace()``
+.. function:: getAvailableSpace()
+   :noindex:
 
    Get available space in bytes.
 
-   Returns ``integer`` ``float``
+   :rtype: integer|float
 
 .. _zend.cache.storage.adapter.methods-total-space-capable-interface:
 
@@ -336,14 +292,12 @@ The TotalSpaceCapableInterface
 The ``Zend\Cache\Storage\TotalSpaceCapableInterface`` implements a method to
 make it possible getting the total space of the storage.
 
-.. _zend.cache.storage.adapter.methods.get-total-space:
-
-**getTotalSpace**
-   ``getTotalSpace()``
+.. function:: getTotalSpace()
+   :noindex:
 
    Get total space in bytes.
 
-   Returns ``integer`` ``float``
+   :rtype: integer|float
 
 .. _zend.cache.storage.adapter.methods-clear-by-namespace-interface:
 
@@ -353,14 +307,12 @@ The ClearByNamespaceInterface
 The ``Zend\Cache\Storage\ClearByNamespaceInterface`` implements a method to
 clear all items of a given namespace.
 
-.. _zend.cache.storage.adapter.methods.clear-by-namespace:
-
-**clearByNamespace**
-   ``clearByNamespace(string $namespace)``
+.. function:: clearByNamespace(string $namespace)
+   :noindex:
 
    Remove items of given namespace.
 
-   Returns ``boolean``
+   :rtype: boolean
 
 .. _zend.cache.storage.adapter.methods-clear-by-prefix-interface
 
@@ -370,14 +322,12 @@ The ClearByPrefixInterface
 The ``Zend\Cache\Storage\ClearByPrefixInterface`` implements a method to clear
 all items of a given prefix (within the current configured namespace).
 
-.. _zend.cache.storage.adapter.methods.clear-by-prefix:
-
-**clearByPrefix**
-   ``clearByPrefix(string $prefix)``
+.. function:: clearByPrefix(string $prefix)
+   :noindex:
 
    Remove items matching given prefix.
 
-   Returns ``boolean``
+   :rtype: boolean
 
 .. _zend.cache.storage.adapter.methods-clear-expired-interface
 
@@ -387,14 +337,12 @@ The ClearExpiredInterface
 The ``Zend\Cache\Storage\ClearExpiredInterface`` implements a method to clear
 all expired items (within the current configured namespace).
 
-.. _zend.cache.storage.adapter.methods.clear-expired:
-
-**clearExpired**
-   ``clearExpired()``
+.. function:: clearExpired()
+   :noindex:
 
    Remove expired items.
 
-   Returns ``boolean``
+   :rtype: boolean
 
 .. _zend.cache.storage.adapter.methods-flushable-interface
 
@@ -404,14 +352,12 @@ The FlushableInterface
 The ``Zend\Cache\Storage\FlushableInterface`` implements a method to flush
 the complete storage.
 
-.. _zend.cache.storage.adapter.methods.flush:
-
-**flush**
-   ``flush()``
+.. function:: flush()
+   :noindex:
 
    Flush the whole storage.
 
-   Returns ``boolean``
+   :rtype: boolean
 
 .. _zend.cache.storage.adapter.methods-iterable-interface
 
@@ -422,14 +368,12 @@ The ``Zend\Cache\Storage\IterableInterface`` implements a method to get an
 iterator to iterate over items of the storage. It extends ``IteratorAggregate``
 so it's possible to directly iterator over the storage using ``foreach``.
 
-.. _zend.cache.storage.adapter.methods.get-iterator:
-
-**getIterator**
-   ``getIterator()``
+.. function:: getIterator()
+   :noindex:
 
    Get an Iterator.
 
-   Returns ``Zend\Cache\Storage\IteratorInterface``
+   :rtype: Zend\\Cache\\Storage\\IteratorInterface
 
 .. _zend.cache.storage.adapter.methods-optimizable-interface
 
@@ -439,14 +383,12 @@ The OptimizableInterface
 The ``Zend\Cache\Storage\OptimizableInterface`` implements a method to run
 optimization processes on the storage.
 
-.. _zend.cache.storage.adapter.methods.optimize:
-
-**optimize**
-   ``optimize()``
+.. function:: optimize()
+   :noindex:
 
    Optimize the storage.
 
-   Returns ``boolean``
+   :rtype: boolean
 
 .. _zend.cache.storage.adapter.methods-taggable-interface
 
@@ -456,36 +398,30 @@ The TaggableInterface
 The ``Zend\Cache\Storage\TaggableInterface`` implements methods to mark items
 with one or more tags and to clean items matching tags.
 
-.. _zend.cache.storage.adapter.methods.set-tags:
-
-**setTags**
-   ``setTags(string $key, string[] $tags)``
+.. function:: setTags(string $key, string[] $tags)
+   :noindex:
 
    Set tags to an item by given key.
    (An empty array will remove all tags)
 
-   Returns ``boolean``
+   :rtype: boolean
 
-.. _zend.cache.storage.adapter.methods.get-tags:
-
-**getTags**
-   ``getTags(string $key)``
+.. function:: getTags(string $key)
+   :noindex:
 
    Get tags of an item by given key.
 
-   Returns ``string[]`` ``false``
+   :rtype: string[]|false
 
-.. _zend.cache.storage.adapter.methods.get-tags:
-
-**clearByTags**
-   ``clearByTags(string[] $tags, boolean $disjunction = false)``
+.. function:: clearByTags(string[] $tags, boolean $disjunction = false)
+   :noindex:
 
    Remove items matching given tags.
 
    If $disjunction is ``true`` only one of the given tags must match
    else all given tags must match.
 
-   Returns ``boolean``
+   :rtype: boolean
 
 .. _zend.cache.storage.adapter.apc
 

--- a/docs/languages/en/modules/zend.cache.storage.capabilities.rst
+++ b/docs/languages/en/modules/zend.cache.storage.capabilities.rst
@@ -24,212 +24,166 @@ marker object and can create your own marker to instantiate a new object of ``Ze
 Available Methods
 -----------------
 
-.. _zend.cache.storage.capabilities.methods.__construct:
-
-**__construct**
-   ``__construct(Zend\Cache\Storage\StorageInterface $storage, stdClass $marker, array $capabilities = array(), Capabilities $baseCapabilities = null)``
+.. function:: __construct(Zend\\Cache\\Storage\\StorageInterface $storage, stdClass $marker, array $capabilities = array(), Zend\\Cache\\Storage\\Capabilities|null $baseCapabilities = null)
+   :noindex:
 
    Constructor
 
-.. _zend.cache.storage.capabilities.methods.get-supported-datatypes:
+.. function:: getSupportedDatatypes()
+   :noindex:
 
-**getSupportedDatatypes**
-   ``getSupportedDatatypes()``
+   Get supported datatypes.
+   
+   :rtype: array
 
-   Get supported datatypes
-
-   Returns ``array``
-
-.. _zend.cache.storage.capabilities.methods.set-supported-datatypes:
-
-**setSupportedDatatypes**
-   ``setSupportedDatatypes(stdClass $marker, array $datatypes)``
+.. function:: setSupportedDatatypes(stdClass $marker, array $datatypes)
+   :noindex:
 
    Set supported datatypes.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-supported-metadata:
-
-**getSupportedMetadata**
-   ``getSupportedMetadata()``
+.. function:: getSupportedMetadata()
+   :noindex:
 
    Get supported metadata.
+   
+   :rtype: array
 
-   Returns array.
+.. function:: setSupportedMetadata(stdClass $marker, string $metadata)
+   :noindex:
 
-.. _zend.cache.storage.capabilities.methods.set-supported-metadata:
+   Set supported metadata.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-**setSupportedMetadata**
-   ``setSupportedMetadata(stdClass $marker, string $metadata)``
+.. function:: getMinTtl()
+   :noindex:
 
-   Set supported metadata
+   Get minimum supported time-to-live.
+   
+   (Returning 0 means items never expire) 
+   
+   :rtype: integer
 
-   Implements a fluent interface.
+.. function:: setMinTtl(stdClass $marker, int $minTtl)
+   :noindex:
 
+   Set minimum supported time-to-live.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-.. _zend.cache.storage.capabilities.methods.get-min-ttl:
+.. function:: getMaxTtl()
+   :noindex:
 
-**getMinTtl**
-   ``getMinTtl()``
+   Get maximum supported time-to-live.
+   
+   :rtype: integer
 
-   Get minimum supported time-to-live
+.. function:: setMaxTtl(stdClass $marker, int $maxTtl)
+   :noindex:
 
-   Returns int (0 means items never expire)
+   Set maximum supported time-to-live.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-.. _zend.cache.storage.capabilities.methods.set-min-ttl:
-
-**setMinTtl**
-   ``setMinTtl(stdClass $marker, int $minTtl)``
-
-   Set minimum supported time-to-live
-
-   Implements a fluent interface.
-
-
-.. _zend.cache.storage.capabilities.methods.get-max-ttl:
-
-**getMaxTtl**
-   ``getMaxTtl()``
-
-   Get maximum supported time-to-live
-
-   Returns int
-
-.. _zend.cache.storage.capabilities.methods.set-max-ttl:
-
-**setMaxTtl**
-   ``setMaxTtl(stdClass $marker, int $maxTtl)``
-
-   Set maximum supported time-to-live
-
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-static-ttl:
-
-**getStaticTtl**
-   ``getStaticTtl()``
+.. function:: getStaticTtl()
+   :noindex:
 
    Is the time-to-live handled static (on write), or dynamic (on read).
+   
+   :rtype: boolean
 
-   Returns boolean
+.. function:: setStaticTtl(stdClass $marker, boolean $flag)
+   :noindex:
 
-.. _zend.cache.storage.capabilities.methods.set-static-ttl:
+   Set if the time-to-live is handled statically (on write) or dynamically (on read).
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-**setStaticTtl**
-   ``setStaticTtl(stdClass $marker, boolean $flag)``
-
-   Set if the time-to-live is handled statically (on write) or dynamically (on read)
-
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-ttl-precision:
-
-**getTtlPrecision**
-   ``getTtlPrecision()``
+.. function:: getTtlPrecision()
+   :noindex:
 
    Get time-to-live precision.
+   
+   :rtype: float
 
-   Returns float.
-
-.. _zend.cache.storage.capabilities.methods.set-ttl-precision:
-
-**setTtlPrecision**
-   ``setTtlPrecision(stdClass $marker, float $ttlPrecision)``
+.. function:: setTtlPrecision(stdClass $marker, float $ttlPrecision)
+   :noindex:
 
    Set time-to-live precision.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-   Implements a fluent interface.
+.. function:: getUseRequestTime()
+   :noindex:
 
-.. _zend.cache.storage.capabilities.methods.get-use-request-time:
+   Get the "use request time" flag status.
+   
+   :rtype: boolean
 
-**getUseRequestTime**
-   ``getUseRequestTime()``
-
-   Get the "use request time" flag status
-
-   Returns boolean
-
-.. _zend.cache.storage.capabilities.methods.set-use-request-time:
-
-**setUseRequestTime**
-   ``setUseRequestTime(stdClass $marker, boolean $flag)``
+.. function:: setUseRequestTime(stdClass $marker, boolean $flag)
+   :noindex:
 
    Set the "use request time" flag.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-expired-read:
-
-**getExpiredRead**
-   ``getExpiredRead()``
+.. function:: getExpiredRead()
+   :noindex:
 
    Get flag indicating if expired items are readable.
+   
+   :rtype: boolean
 
-   Returns boolean
-
-.. _zend.cache.storage.capabilities.methods.set-expired-read:
-
-**setExpiredRead**
-   ``setExpiredRead(stdClass $marker, boolean $flag)``
+.. function:: setExpiredRead(stdClass $marker, boolean $flag)
+   :noindex:
 
    Set if expired items are readable.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-max-key-length:
-
-**getMaxKeyLength**
-   ``getMaxKeyLength()``
+.. function:: getMaxKeyLength()
+   :noindex:
 
    Get maximum key lenth.
+   
+   :rtype: integer
 
-   Returns int
-
-.. _zend.cache.storage.capabilities.methods.set-max-key-length:
-
-**setMaxKeyLength**
-   ``setMaxKeyLength(stdClass $marker, int $maxKeyLength)``
+.. function:: setMaxKeyLength(stdClass $marker, int $maxKeyLength)
+   :noindex:
 
    Set maximum key lenth.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-namespace-is-prefix:
-
-**getNamespaceIsPrefix**
-   ``getNamespaceIsPrefix()``
+.. function:: getNamespaceIsPrefix()
+   :noindex:
 
    Get if namespace support is implemented as a key prefix.
+   
+   :rtype: boolean
 
-   Returns boolean
-
-.. _zend.cache.storage.capabilities.methods.set-namespace-is-prefix:
-
-**setNamespaceIsPrefix**
-   ``setNamespaceIsPrefix(stdClass $marker, boolean $flag)``
+.. function:: setNamespaceIsPrefix(stdClass $marker, boolean $flag)
+   :noindex:
 
    Set if namespace support is implemented as a key prefix.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
-   Implements a fluent interface.
-
-.. _zend.cache.storage.capabilities.methods.get-namespace-separator:
-
-**getNamespaceSeparator**
-   ``getNamespaceSeparator()``
+.. function:: getNamespaceSeparator()
+   :noindex:
 
    Get namespace separator if namespace is implemented as a key prefix.
+   
+   :rtype: string
 
-   Returns string
-
-.. _zend.cache.storage.capabilities.methods.set-namespace-separator:
-
-**setNamespaceSeparator**
-   ``setNamespaceSeparator(stdClass $marker, string $separator)``
+.. function:: setNamespaceSeparator(stdClass $marker, string $separator)
+   :noindex:
 
    Set the namespace separator if namespace is implemented as a key prefix.
-
-   Implements a fluent interface.
+   
+   :rtype: Zend\\Cache\\Storage\\Capabilities
 
 .. _zend.cache.storage.capabilities.examples:
 

--- a/docs/languages/en/modules/zend.cache.storage.plugin.rst
+++ b/docs/languages/en/modules/zend.cache.storage.plugin.rst
@@ -169,41 +169,33 @@ The Serializer Plugin
 Available Methods
 -----------------
 
-.. _zend.cache.storage.plugin.methods.set-options:
+.. function:: setOptions(Zend\\Cache\\Storage\\Plugin\\PluginOptions $options)
+   :noindex:
 
-**setOptions**
-   ``setOptions(Zend\Cache\Storage\Plugin\PluginOptions $options)``
+   Set options.
 
-   Set options
+   :rtype: Zend\\Cache\\Storage\\Plugin\\PluginInterface
 
-   Implements a fluent interface.
+.. function:: getOptions()
+   :noindex:
 
-.. _zend.cache.storage.plugin.methods.get-options:
+   Get options.
 
-**getOptions**
-   ``getOptions()``
+   :rtype: Zend\\Cache\\Storage\\Plugin\\PluginOptions
 
-   Get options
+.. function:: attach(Zend\\EventManager\\EventManagerInterface $events)
+   :noindex:
 
-   Returns PluginOptions
+   Defined by ``Zend\EventManager\ListenerAggregateInterface``, attach one or more listeners.
 
-.. _zend.cache.storage.plugin.methods.attach:
+   :rtype: void
 
-**attach**
-   ``attach(EventCollection $events)``
+.. function:: detach(Zend\\EventManager\\EventManagerInterface $events)
+   :noindex:
 
-   Defined by ``Zend\EventManager\ListenerAggregate``, attach one or more listeners.
+   Defined by ``Zend\EventManager\ListenerAggregateInterface``, detach all previously attached listeners.
 
-   Returns void
-
-.. _zend.cache.storage.plugin.methods.detach:
-
-**detach**
-   ``detach(EventCollection $events)``
-
-   Defined by ``Zend\EventManager\ListenerAggregate``, detach all previously attached listeners.
-
-   Returns void
+   :rtype: void
 
 .. _zend.cache.storage.plugin.examples:
 


### PR DESCRIPTION
- The headline no longer contains the complete class name.
  Therefor the description contains it.
  - Makes the navigation on the left side readable
- fixed some inline snipped using `snipped`
