### PR TITLE
Update docs/languages/en/modules/zend.authentication.adapter.ldap.rst

### DIFF
--- a/docs/languages/en/modules/zend.authentication.adapter.ldap.rst
+++ b/docs/languages/en/modules/zend.authentication.adapter.ldap.rst
@@ -65,12 +65,12 @@ not using ``Zend\Mvc``, the meat of your code should look something like the fol
        $logger->addWriter($writer);
 
        $filter = new LogFilter(Logger::DEBUG);
-       $logger->addFilter($filter);
+       $writer->addFilter($filter);
 
        foreach ($messages as $i => $message) {
            if ($i-- > 1) { // $messages[2] and up are log messages
                $message = str_replace("\n", "\n  ", $message);
-               $logger->log("Ldap: $i: $message", Logger::DEBUG);
+               $logger->log(Logger::DEBUG, "Ldap: $i: $message");
            }
        }
    }


### PR DESCRIPTION
I believe that addFilter is part of the $writer not the $logger.  With the example, I get the following error:

Fatal error: Call to undefined method Zend\Log\Logger::addFilter()

Also, it seems the parameters have been reversed for $logger->log() with priority now first.  With the example, I get the following error:

Zend\Log\Exception\InvalidArgumentException
$priority must be an integer > 0 and < 8; received 'Ldap: message'
