### PR TITLE
Updated the en/modules/zend.service-manager.quick-start.rst file

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.quick-start.rst
+++ b/docs/languages/en/modules/zend.service-manager.quick-start.rst
@@ -8,7 +8,7 @@ providing services, invokable classes, aliases, and factories either via configu
 
 By default, the module manager listener ``Zend\ModuleManager\Listener\ServiceListener`` will do the following:
 
-- For modules implementing the ``Zend\ModuleManager\Feature\ServiceProvider`` interface, or the
+- For modules implementing ``Zend\ModuleManager\Feature\ServiceProviderInterface``, or the
   ``getServiceConfig()`` method, it will call that method and merge the configuration.
 
 - After all modules have been processed, it will grab the configuration from the registered


### PR DESCRIPTION
Some namespaces in the documentation did not match the actual namespace of the class/interface.
