### PR TITLE
fixed grouped options example

### DIFF
--- a/docs/languages/en/modules/zend.form.element.select.rst
+++ b/docs/languages/en/modules/zend.form.element.select.rst
@@ -89,15 +89,20 @@ Option groups are also supported. You just need to add an 'options' key to the v
    	$select = new Element\Select('language');
    	$select->setLabel('Which is your mother tongue?');
    	$select->setValueOptions(array(
-   		'options' => array(
-   			'European languages' => array(
-   				'0' => 'French',
-   				'1' => 'Italian',
+   			'european' => array(
+               'label' => 'European languages',
+      	      'options' => array(
+   				   '0' => 'French',
+   				   '1' => 'Italian',
+               ),
    			),
-   			'Asian languages' => array(
-   				'2' => 'Japanese',
-   				'3' => 'Chinese',
-   			)
+   			'asian' => array(
+               'label' => 'Asian languages',
+      	      'options' => array(
+   				   '2' => 'Japanese',
+   				   '3' => 'Chinese',
+               ),
+   			),
    		)   		
    	));
 


### PR DESCRIPTION
Each optgroup should have an 'options' value, not the other way around.
The example previously did not work; now it does :)
Also, I added a 'label' entry, as options were not named without it. This might be a bug in FormSelect view helper.
