### PR TITLE
Update docs/languages/en/user-guide/database-and-models.rst

### DIFF
--- a/docs/languages/en/user-guide/database-and-models.rst
+++ b/docs/languages/en/user-guide/database-and-models.rst
@@ -343,7 +343,7 @@ Testing
 
 Let's write a few tests for all this code we've just written. First, we need
 to create a test class for the ``AlbumTable``.
-Create a file ``AlbumTableTest.php`` in ``module/Album/test/AlbumTableTest/Model``
+Create a file ``AlbumTableTest.php`` in ``module/Album/test/AlbumTest/Model``
 
 .. code-block:: php
 


### PR DESCRIPTION
Changed what I think was a typo: module/Album/test/AlbumTableTest/Model to module/Album/test/AlbumTest/Model
