### PR TITLE
Avoid full rebuilds by copying files to tmp/ with preserved mtime

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 pre-build:
 	@rm -rf tmp/$(LANG)
 	@mkdir -p tmp/$(LANG)
-	@cp -R languages/en/* tmp/$(LANG)/
+	@cp -Rp languages/en/* tmp/$(LANG)/
 ifneq ($(LANG),en)
 	@for f in $$(cd languages/$(LANG) && find . -type f \( ! -iname ".*" \) | sort); do \
 		if [ -f languages/en/$$f ]; then \


### PR DESCRIPTION
In the current Makefile in pre-build all files are copied to tmp/ thus their modification time is changed, causing a full rebuild even if most files did not change. 

This small fix adds the -p flag to cp causing all file attributes including mtime to be preserved. I've tested it on OS X only. 
