### PR TITLE
Cleanup of Form Element doc TOC headings

### DIFF
--- a/docs/languages/en/modules/zend.form.element.button.rst
+++ b/docs/languages/en/modules/zend.form.element.button.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.button:
 
-Button Element
-^^^^^^^^^^^^^^
+Button
+^^^^^^
 
 ``Zend\Form\Element\Button`` represents a button form input.
 It can be used with the ``Zend/Form/View/Helper/FormButton`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend/Form/View/Helper/FormButton`` view helper.
 
 .. _zend.form.element.button.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``type`` attribute of value ``button``.
 

--- a/docs/languages/en/modules/zend.form.element.captcha.rst
+++ b/docs/languages/en/modules/zend.form.element.captcha.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.captcha:
 
-Captcha Element
-^^^^^^^^^^^^^^^
+Captcha
+^^^^^^^
 
 ``Zend\Form\Element\Captcha`` can be used with forms where authenticated users are not necessary, but you want to prevent
 spam submissions. It is pairs with one of the ``Zend/Form/View/Helper/Captcha/*`` view helpers that matches the
@@ -9,8 +9,7 @@ type of *CAPTCHA* adapter in use.
 
 .. _zend.form.element.captcha.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 A *CAPTCHA* adapter must be attached in order for validation to be included in the element's input filter
 specification. See the section on :ref:`Zend CAPTCHA Adapters <zend.captcha.adapters>` for more information on what
@@ -51,8 +50,7 @@ Here is with the array notation:
     
 .. _zend.form.element.captcha.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.checkbox.rst
+++ b/docs/languages/en/modules/zend.form.element.checkbox.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.checkbox:
 
-Checkbox Element
-^^^^^^^^^^^^^^^^
+Checkbox
+^^^^^^^^
 
 ``Zend\Form\Element\Checkbox`` is meant to be paired with the ``Zend\Form\View\Helper\FormCheckbox`` for
 HTML inputs with type checkbox. This element adds an ``InArray`` validator to its input filter specification
@@ -9,8 +9,7 @@ in order to validate on the server if the checkbox contains either the checked v
 
 .. _zend.form.element.checkbox.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"checkbox"``.
 
@@ -51,8 +50,7 @@ Using the array notation:
 
 .. _zend.form.element.checkbox.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element <zend.form.element.methods>` .
 

--- a/docs/languages/en/modules/zend.form.element.collection.rst
+++ b/docs/languages/en/modules/zend.form.element.collection.rst
@@ -1,5 +1,5 @@
-Collection Element
-^^^^^^^^^^^^^^^^^^
+Collection
+^^^^^^^^^^
 
 Sometimes, you may want to add input (or a set of inputs) multiple times, either because you don't want
 to duplicate code, or because you does not know in advance how many elements you need (in the case of elements
@@ -10,8 +10,7 @@ to :ref:`Zend\Collection tutorial <zend.form.collections>`.
 
 .. _zend.form.element.collection.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 .. code-block:: php
    :linenos:
@@ -49,8 +48,7 @@ Using the array notation:
 
 .. _zend.form.element.collection.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element <zend.form.element.methods>` .
 

--- a/docs/languages/en/modules/zend.form.element.color.rst
+++ b/docs/languages/en/modules/zend.form.element.color.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.color:
 
-Color Element
-^^^^^^^^^^^^^
+Color
+^^^^^
 
 ``Zend\Form\Element\Color`` is meant to be paired with the ``Zend\Form\View\Helper\FormColo
 type color`_. This element adds filters and a ``Regex`` validator to it's input filter spr`` for `HTML5 inputs withecification in order to
@@ -9,8 +9,7 @@ validate a `HTML5 valid simple color`_ value on the server.
 
 .. _zend.form.element.color.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"color"``.
 
@@ -44,8 +43,7 @@ Here is the same example using the array notation:
 
 .. _zend.form.element.color.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.csrf.rst
+++ b/docs/languages/en/modules/zend.form.element.csrf.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.csrf:
 
-Csrf Element
-^^^^^^^^^^^^
+Csrf
+^^^^
 
 ``Zend\Form\Element\Csrf`` pairs with the ``Zend\Form\View\Helper\FormHidden`` to provide protection from *CSRF* attacks
 on forms, ensuring the data is submitted by the user session that generated the form and not by a rogue script.
@@ -9,8 +9,7 @@ Protection is achieved by adding a hash element to a form and verifying it when 
 
 .. _zend.form.element.csrf.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"hidden"``.
 
@@ -45,8 +44,7 @@ You can change the options of the CSRF validator using the ``setCsrfValidatorOpt
 
 .. _zend.form.element.csrf.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.date.rst
+++ b/docs/languages/en/modules/zend.form.element.date.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.date:
 
-Date Element
-^^^^^^^^^^^^
+Date
+^^^^
 
 ``Zend\Form\Element\Date`` is meant to be paired with the ``Zend\Form\View\Helper\FormDate`` for `HTML5 inputs with type
 date`_. This element adds filters and validators to it's input filter specification in order to validate HTML5 date
@@ -9,8 +9,7 @@ input values on the server.
 
 .. _zend.form.element.date.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"date"``.
 
@@ -60,8 +59,7 @@ Here is with the array notation:
 
 .. _zend.form.element.date.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\DateTime
 <zend.form.element.date-time.methods>`.

--- a/docs/languages/en/modules/zend.form.element.date.time.local.rst
+++ b/docs/languages/en/modules/zend.form.element.date.time.local.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.date-time-local:
 
-DateTimeLocal Element
-^^^^^^^^^^^^^^^^^^^^^
+DateTimeLocal
+^^^^^^^^^^^^^
 
 ``Zend\Form\Element\DateTimeLocal`` is meant to be paired with the ``Zend\Form\View\Helper\FormDateTimeLocal`` for `HTML5
 inputs with type datetime-local`_. This element adds filters and validators to it's input filter specification in
@@ -9,8 +9,7 @@ order to validate HTML5 a local datetime input values on the server.
 
 .. _zend.form.element.date-time-local.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"datetime-local"``.
 
@@ -60,8 +59,7 @@ Here is with the array notation:
 
 .. _zend.form.element.date-time-local.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\DateTime
 <zend.form.element.date-time.methods>`.

--- a/docs/languages/en/modules/zend.form.element.date.time.rst
+++ b/docs/languages/en/modules/zend.form.element.date.time.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.date-time:
 
-DateTime Element
-^^^^^^^^^^^^^^^^
+DateTime
+^^^^^^^^
 
 ``Zend\Form\Element\DateTime`` is meant to be paired with the ``Zend\Form\View\Helper\FormDateTime`` for `HTML5 inputs
 with type datetime`_. This element adds filters and validators to it's input filter specification in order to
@@ -9,8 +9,7 @@ validate HTML5 datetime input values on the server.
 
 .. _zend.form.element.date-time.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"datetime"``.
 
@@ -60,8 +59,7 @@ Here is with the array notation:
 
 .. _zend.form.element.date-time.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.email.rst
+++ b/docs/languages/en/modules/zend.form.element.email.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.email:
 
-Email Element
-^^^^^^^^^^^^^
+Email
+^^^^^
 
 ``Zend\Form\Element\Email`` is meant to be paired with the ``Zend\Form\View\Helper\FormEmail`` for `HTML5 inputs with
 type email`_. This element adds filters and validators to it's input filter specification in order to validate
@@ -9,8 +9,7 @@ type email`_. This element adds filters and validators to it's input filter spec
 
 .. _zend.form.element.email.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"email"``.
 
@@ -68,8 +67,7 @@ Here is with the array notation:
 
 .. _zend.form.element.email.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.file.rst
+++ b/docs/languages/en/modules/zend.form.element.file.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.file:
 
-File Element
-^^^^^^^^^^^^
+File
+^^^^
 
 ``Zend\Form\Element\File`` represents a form file input.
 It can be used with the ``Zend\Form\View\Helper\FormFile`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormFile`` view helper.
 
 .. _zend.form.element.file.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"file"``,
 and will set the form's enctype to ``multipart/form-data``.

--- a/docs/languages/en/modules/zend.form.element.hidden.rst
+++ b/docs/languages/en/modules/zend.form.element.hidden.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.hidden:
 
-Hidden Element
-^^^^^^^^^^^^^^
+Hidden
+^^^^^^
 
 ``Zend\Form\Element\Hidden`` represents a hidden form input.
 It can be used with the ``Zend\Form\View\Helper\FormHidden`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormHidden`` view helper.
 
 .. _zend.form.element.hidden.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"hidden"``.
 

--- a/docs/languages/en/modules/zend.form.element.image.rst
+++ b/docs/languages/en/modules/zend.form.element.image.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.image:
 
-Image Element
-^^^^^^^^^^^^^
+Image
+^^^^^
 
 ``Zend\Form\Element\Image`` represents a image button form input.
 It can be used with the ``Zend\Form\View\Helper\FormImage`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormImage`` view helper.
 
 .. _zend.form.element.image.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"image"``.
 

--- a/docs/languages/en/modules/zend.form.element.month.rst
+++ b/docs/languages/en/modules/zend.form.element.month.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.month:
 
-Month Element
-^^^^^^^^^^^^^
+Month
+^^^^^
 
 ``Zend\Form\Element\Month`` is meant to be paired with the ``Zend\Form\View\Helper\FormMonth`` for `HTML5 inputs with
 type month`_. This element adds filters and validators to it's input filter specification in order to validate
@@ -9,8 +9,7 @@ HTML5 month input values on the server.
 
 .. _zend.form.element.month.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"month"``.
 
@@ -60,8 +59,7 @@ Here is with the array notation:
 
 .. _zend.form.element.month.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\DateTime
 <zend.form.element.date-time.methods>`.

--- a/docs/languages/en/modules/zend.form.element.multicheckbox.rst
+++ b/docs/languages/en/modules/zend.form.element.multicheckbox.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.multicheckbox:
 
-MultiCheckbox Element
-^^^^^^^^^^^^^^^^^^^^^
+MultiCheckbox
+^^^^^^^^^^^^^
 
 ``Zend\Form\Element\MultiCheckbox`` is meant to be paired with the ``Zend\Form\View\Helper\FormMultiCheckbox``
 for HTML inputs with type checkbox. This element adds an ``InArray`` validator to its input filter specification
@@ -9,8 +9,7 @@ in order to validate on the server if the checkbox contains values from the mult
 
 .. _zend.form.element.multicheckbox.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"checkbox"`` for every checkboxes.
 
@@ -57,8 +56,7 @@ Using the array notation:
 
 .. _zend.form.element.multicheckbox.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\Checkbox <zend.form.element.checkbox.methods>` .
 

--- a/docs/languages/en/modules/zend.form.element.number.rst
+++ b/docs/languages/en/modules/zend.form.element.number.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.number:
 
-Number Element
-^^^^^^^^^^^^^^
+Number
+^^^^^^
 
 ``Zend\Form\Element\Number`` is meant to be paired with the ``Zend\Form\View\Helper\FormNumber`` for `HTML5 inputs with
 type number`_. This element adds filters and validators to it's input filter specification in order to validate
@@ -9,8 +9,7 @@ HTML5 number input values on the server.
 
 .. _zend.form.element.number.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"number"``.
 
@@ -60,8 +59,7 @@ Here is with the array notation:
 
 .. _zend.form.element.number.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.password.rst
+++ b/docs/languages/en/modules/zend.form.element.password.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.password:
 
-Password Element
-^^^^^^^^^^^^^^^^
+Password
+^^^^^^^^
 
 ``Zend\Form\Element\Password`` represents a password form input.
 It can be used with the ``Zend\Form\View\Helper\FormPassword`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormPassword`` view helper.
 
 .. _zend.form.element.password.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"password"``.
 

--- a/docs/languages/en/modules/zend.form.element.radio.rst
+++ b/docs/languages/en/modules/zend.form.element.radio.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.radio:
 
-Radio Element
-^^^^^^^^^^^^^
+Radio
+^^^^^
 
 ``Zend\Form\Element\Radio`` is meant to be paired with the ``Zend\Form\View\Helper\FormRadio`` for HTML inputs
 with type radio. This element adds an ``InArray`` validator to its input filter specification in order to validate
@@ -9,8 +9,7 @@ on the server if the value is contains within the radio value elements.
 
 .. _zend.form.element.radio.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"radio"`` for every radio.
 
@@ -55,7 +54,6 @@ Using the array notation:
 
 .. _zend.form.element.radio.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 All the methods from the inherited :ref:`methods of Zend\\Form\\Element\\MultiCheckbox <zend.form.element.multicheckbox.methods>` are also available for this element.

--- a/docs/languages/en/modules/zend.form.element.range.rst
+++ b/docs/languages/en/modules/zend.form.element.range.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.range:
 
-Range Element
-^^^^^^^^^^^^^
+Range
+^^^^^
 
 ``Zend\Form\Element\Range`` is meant to be paired with the ``Zend\Form\View\Helper\FormRange`` for `HTML5 inputs with
 type range`_. This element adds filters and validators to it's input filter specification in order to validate
@@ -9,8 +9,7 @@ HTML5 range values on the server.
 
 .. _zend.form.element.range.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"range"``.
 
@@ -60,8 +59,7 @@ Here is with the array notation:
 
 .. _zend.form.element.range.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\Number
 <zend.form.element.number.methods>`.

--- a/docs/languages/en/modules/zend.form.element.rst
+++ b/docs/languages/en/modules/zend.form.element.rst
@@ -7,8 +7,7 @@ Element Base Class
 
 .. _zend.form.element.usage:
 
-Basic Usage
-^^^^^^^^^^^
+.. rubric:: Basic Usage
 
 At the bare minimum, each element or fieldset requires a name. You will also typically provide some attributes to
 hint to the view layer how it might render the item.
@@ -41,8 +40,7 @@ hint to the view layer how it might render the item.
 
 .. _zend.form.element.methods:
 
-Public Methods
-^^^^^^^^^^^^^^
+.. rubric:: Public Methods
 
 .. function:: setName(string $name)
    :noindex:

--- a/docs/languages/en/modules/zend.form.element.select.rst
+++ b/docs/languages/en/modules/zend.form.element.select.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.select:
 
-Select Element
-^^^^^^^^^^^^^^
+Select
+^^^^^^
 
 ``Zend\Form\Element\Select`` is meant to be paired with the ``Zend\Form\View\Helper\FormSelect`` for HTML inputs
 with type select. This element adds an ``InArray`` validator to its input filter specification in order to validate
@@ -10,8 +10,7 @@ the "multiple" HTML attribute to the element.
 
 .. _zend.form.element.select.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"select"``.
 
@@ -110,8 +109,7 @@ Option groups are also supported. You just need to add an 'options' key to the v
 
 .. _zend.form.element.select.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element <zend.form.element.methods>` .
 

--- a/docs/languages/en/modules/zend.form.element.submit.rst
+++ b/docs/languages/en/modules/zend.form.element.submit.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.submit:
 
-Submit Element
-^^^^^^^^^^^^^^
+Submit
+^^^^^^
 
 ``Zend\Form\Element\Submit`` represents a submit button form input.
 It can be used with the ``Zend\Form\View\Helper\FormSubmit`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormSubmit`` view helper.
 
 .. _zend.form.element.submit.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"submit"``.
 

--- a/docs/languages/en/modules/zend.form.element.text.rst
+++ b/docs/languages/en/modules/zend.form.element.text.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.text:
 
-Text Element
-^^^^^^^^^^^^
+Text
+^^^^
 
 ``Zend\Form\Element\Text`` represents a text form input.
 It can be used with the ``Zend\Form\View\Helper\FormText`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormText`` view helper.
 
 .. _zend.form.element.text.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"text"``.
 

--- a/docs/languages/en/modules/zend.form.element.textarea.rst
+++ b/docs/languages/en/modules/zend.form.element.textarea.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.textarea:
 
-Textarea Element
-^^^^^^^^^^^^^^^^
+Textarea
+^^^^^^^^
 
 ``Zend\Form\Element\Textarea`` represents a textarea form input.
 It can be used with the ``Zend\Form\View\Helper\FormTextarea`` view helper.
@@ -10,8 +10,7 @@ It can be used with the ``Zend\Form\View\Helper\FormTextarea`` view helper.
 
 .. _zend.form.element.textarea.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 .. code-block:: php
    :linenos:

--- a/docs/languages/en/modules/zend.form.element.time.rst
+++ b/docs/languages/en/modules/zend.form.element.time.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.time:
 
-Time Element
-^^^^^^^^^^^^
+Time
+^^^^
 
 ``Zend\Form\Element\Time`` is meant to be paired with the ``Zend\Form\View\Helper\FormTime`` for `HTML5 inputs with type
 time`_. This element adds filters and validators to it's input filter specification in order to validate HTML5 time
@@ -9,8 +9,7 @@ input values on the server.
 
 .. _zend.form.element.time.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"time"``.
 
@@ -60,8 +59,7 @@ Here is the same example using the array notation:
 
 .. _zend.form.element.time.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\DateTime
 <zend.form.element.date-time.methods>`.

--- a/docs/languages/en/modules/zend.form.element.url.rst
+++ b/docs/languages/en/modules/zend.form.element.url.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.url:
 
-Url Element
-^^^^^^^^^^^
+Url
+^^^
 
 ``Zend\Form\Element\Url`` is meant to be paired with the ``Zend\Form\View\Helper\FormUrl`` for `HTML5 inputs with type
 url`_. This element adds filters and a ``Zend\Validator\Uri`` validator to it's input filter specification for
@@ -9,8 +9,7 @@ validating HTML5 URL input values on the server.
 
 .. _zend.form.element.url.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"url"``.
 
@@ -44,8 +43,7 @@ Here is the same example using the array notation:
 
 .. _zend.form.element.url.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element
 <zend.form.element.methods>`.

--- a/docs/languages/en/modules/zend.form.element.week.rst
+++ b/docs/languages/en/modules/zend.form.element.week.rst
@@ -1,7 +1,7 @@
 .. _zend.form.element.week:
 
-Week Element
-^^^^^^^^^^^^
+Week
+^^^^
 
 ``Zend\Form\Element\Week`` is meant to be paired with the ``Zend\Form\View\Helper\FormWeek`` for `HTML5 inputs with type
 week`_. This element adds filters and validators to it's input filter specification in order to validate HTML5 week
@@ -9,8 +9,7 @@ input values on the server.
 
 .. _zend.form.element.week.usage:
 
-Basic Usage
-"""""""""""
+.. rubric:: Basic Usage
 
 This element automatically adds a ``"type"`` attribute of value ``"week"``.
 
@@ -60,8 +59,7 @@ Here is the same example using the array notation:
 
 .. _zend.form.element.week.methods:
 
-Public Methods
-""""""""""""""
+.. rubric:: Public Methods
 
 The following methods are in addition to the inherited :ref:`methods of Zend\\Form\\Element\\DateTime
 <zend.form.element.date-time.methods>`.


### PR DESCRIPTION
The table of contents for the Zend\Form Element docs has a lot of redundant headings for each element, making it somewhat unreadable.

This cleans up the TOC headings (by using rubric markup).
