### PR TITLE
Update docs/languages/en/user-guide/forms-and-actions.rst

### DIFF
--- a/docs/languages/en/user-guide/forms-and-actions.rst
+++ b/docs/languages/en/user-guide/forms-and-actions.rst
@@ -110,7 +110,7 @@ going to add the input filter to our ``Album.php`` file in ``module/Album/src/Al
 
         public function getInputFilter()
         {
-            if (!$this->inputFilter) {
+            if (!isset($this->inputFilter)) {
                 $inputFilter = new InputFilter();
                 $factory     = new InputFactory();
 


### PR DESCRIPTION
Method Album\Model\Album::getInputFilter() break, throwing notice because $inputFilter don't exists on first call
