### PR TITLE
Incorrect Cache Adapter Default Namespace

### DIFF
--- a/docs/languages/en/modules/zend.cache.storage.adapter.rst
+++ b/docs/languages/en/modules/zend.cache.storage.adapter.rst
@@ -94,7 +94,7 @@ Basic Configuration Options
    +==============+=========================+================+=================================================+
    |ttl           |``integer``              |0               |Time to live                                     |
    +--------------+-------------------------+----------------+-------------------------------------------------+
-   |namespace     |``string``               |""              |The "namespace" in which cache items will live   |
+   |namespace     |``string``               |"zfcache"       |The "namespace" in which cache items will live   |
    +--------------+-------------------------+----------------+-------------------------------------------------+
    |key_pattern   |``null`` ``string``      |``null``        |Pattern against which to validate cache keys     |
    +--------------+-------------------------+----------------+-------------------------------------------------+


### PR DESCRIPTION
Updates the `Zend\Cache\Storage\Adapter\AdapterOptions` default `namespace` option to what is defined in the [file](https://github.com/zendframework/zf2/blob/master/library/Zend/Cache/Storage/Adapter/AdapterOptions.php#L50).
