### PR TITLE
Update docs/languages/en/modules/zend.console.adapter.rst

### DIFF
--- a/docs/languages/en/modules/zend.console.adapter.rst
+++ b/docs/languages/en/modules/zend.console.adapter.rst
@@ -26,7 +26,7 @@ Service Manager.
     :emphasize-lines: 8
 
     namespace Application;
-    use Zend\Console\AdapterInterface as Console;
+    use Zend\Console\Adapter\AdapterInterface as Console;
 
     class Module
     {


### PR DESCRIPTION
When using this example I found that the "use .. as Console" was referencing Zend\Console\AdapterInterface instead of Zend\Console\Adapter\AdapterInterface

This caused an error when passing the function a Windows console.

PHP Catchable fatal error:  Argument 1 passed to Album\Controller\SetupController::getConsoleUsage() must be an instance of Zend\Console\AdapterInterface, instance of Zend\Console\Adapter\Windows given, called in...
