### PR TITLE
Documenting feature proposed at zendframework/zf2#3443

### DIFF
--- a/docs/languages/en/modules/zend.module-manager.module-manager.rst
+++ b/docs/languages/en/modules/zend.module-manager.module-manager.rst
@@ -62,6 +62,13 @@ By default, Zend Framework provides several useful module manager listeners.
    method. If so, it calls the ``getAutoloaderConfig()`` method on the module class and passes the returned array
    to ``Zend\Loader\AutoloaderFactory``.
 
+**Zend\\ModuleManager\\Listener\\ModuleDependencyCheckerListener**
+   This listener checks each module to verify if all the modules it depends on were loaded.
+   When a module class implements ``Zend\ModuleManager\Feature\DependencyIndicatorInterface`` or simply
+   has a defined ``getDependencyModules()`` method, the listener will call ``getDependencyModules()``. Each of
+   the values returned by the method is checked against the loaded modules list: if one of the values is not in
+   that list, a ``Zend\ModuleManager\Exception\MissingDependencyModuleException`` is be thrown.
+
 **Zend\\ModuleManager\\Listener\\ConfigListener**
    If a module class has a ``getConfig()`` method, or implements ``Zend\ModuleManager\Feature\ConfigProviderInterface``,
    this listener will call it and merge the returned array (or ``Traversable`` object) into the main application configuration.

--- a/docs/languages/en/modules/zend.mvc.services.rst
+++ b/docs/languages/en/modules/zend.mvc.services.rst
@@ -306,6 +306,11 @@ directives go to the ``config/application.config.php`` file.
 
            // The path in which to cache merged configuration.
            'cache_dir' => $stringPath,
+
+           // Whether or not to enable modules dependency checking.
+           // Enabled by default, prevents usage of modules that depend on other modules
+           // that weren't loaded.
+           'check_dependencies' => $booleanValue,
        ),
 
        // Used to create an own service manager. May contain one or more child arrays.


### PR DESCRIPTION
Adding description of how the ModuleDependencyIndicatorInterface works
and how the listener associated to it behaves

See zendframework/zf2#3443
