### PR TITLE
Fix for the way a view helper is retrieved.

### DIFF
--- a/docs/languages/en/modules/zend.view.helpers.navigation.rst
+++ b/docs/languages/en/modules/zend.view.helpers.navigation.rst
@@ -316,7 +316,7 @@ Notes on the setup:
    $container = new Zend\Navigation\Navigation($pages);
 
    // Store the container in the proxy helper:
-   $view->getHelper('navigation')->setContainer($container);
+   $view->plugin('navigation')->setContainer($container);
 
    // ...or simply:
    $view->navigation($container);


### PR DESCRIPTION
The right way is `$this->plugin('HelperName')`, not `$this->getHelper('HelperName')`.
