### PR TITLE
Update docs/languages/en/user-guide/forms-and-actions.rst

### DIFF
--- a/docs/languages/en/user-guide/forms-and-actions.rst
+++ b/docs/languages/en/user-guide/forms-and-actions.rst
@@ -501,9 +501,9 @@ We need to change the test for edit 'AlbumControllerTest'  in ``module/Album/tes
 
     <?php
     ...
-    public function testAddActionCanBeAccessed()
+    public function testEditActionCanBeAccessed()
     {
-        $this->routeMatch->setParam('action', 'add');
+        $this->routeMatch->setParam('action', 'edit');
         $this->routeMatch->setParam('id', '1');//Add this Row
 
         $result   = $this->controller->dispatch($this->request);


### PR DESCRIPTION
The phpunit run shows the testEditActionCanBeAccessed test failing but then says to modify the testAddActionCanBeAccessed test.

This change updates the docs to update the proper test.
