### PR TITLE
Fix references to Zend/Validator/File/UploadFile

### DIFF
--- a/docs/languages/en/modules/zend.form.element.file.rst
+++ b/docs/languages/en/modules/zend.form.element.file.rst
@@ -3,7 +3,9 @@
 File
 ^^^^
 
-``Zend\Form\Element\File`` represents a form file input.
+``Zend\Form\Element\File`` represents a form file input and
+provides a default input specification with a type of :ref:`FileInput <zend.input-filter.file-input>`
+(important for handling validators and filters correctly).
 It can be used with the ``Zend\Form\View\Helper\FormFile`` view helper.
 
 ``Zend\Form\Element\File`` extends from :ref:`Zend\Form\Element <zend.form.element>`.

--- a/docs/languages/en/modules/zend.form.file-upload.rst
+++ b/docs/languages/en/modules/zend.form.file-upload.rst
@@ -12,7 +12,7 @@ handling file uploads in your projects.
 
    If the reader has experience with file uploading in Zend Framework v1.x,
    he/she will notice some major differences.
-   ``Zend_File_Transfer`` has been removed in favor of using the standard ZF2 ``Zend\Form``
+   ``Zend_File_Transfer`` has been deprecated in favor of using the standard ZF2 ``Zend\Form``
    and ``Zend\InputFilter`` features.
 
 .. note::
@@ -75,7 +75,7 @@ The ``File`` element provides some automatic features that happen behind the sce
 - The file element's default input specification will create the correct ``Input`` type:
   :ref:`Zend\\InputFilter\\FileInput <zend.input-filter.file-input>`.
 - The ``FileInput`` will automatically prepend an
-  :ref:`Upload Validator <zend.validator.file.upload>`,
+  :ref:`UploadFile Validator <zend.validator.file.upload-file>`,
   to securely validate that the file is actually an uploaded file, and to report
   other types of upload errors to the user.
 

--- a/docs/languages/en/modules/zend.form.view.helper.form-file.rst
+++ b/docs/languages/en/modules/zend.form.view.helper.form-file.rst
@@ -4,8 +4,8 @@ FormFile
 ^^^^^^^^
 
 The ``FormFile`` view helper can be used to render a ``<input type="file">``
-form input. It is meant to work with the :ref:`Zend\\Form\\Element\\Email <zend.form.element.file>`
-element, which provides a default input specification with a ``FileUpload`` validator.
+form input. It is meant to work with the :ref:`Zend\\Form\\Element\\File <zend.form.element.file>`
+element.
 
 ``FormFile`` extends from :ref:`Zend\\Form\\View\\Helper\\FormInput <zend.form.view.helper.form-input>`.
 

--- a/docs/languages/en/modules/zend.input-filter.file-input.rst
+++ b/docs/languages/en/modules/zend.input-filter.file-input.rst
@@ -12,7 +12,7 @@ While ``FileInput`` uses the same interface as ``Input``, it differs in a few wa
    This is so that any ``is_uploaded_file()`` validation can be run prior to any filters that may
    rename/move/modify the file.
 3. Instead of adding a ``NotEmpty`` validator, it will (by default) automatically add a
-   ``Zend\Validator\File\Upload`` validator.
+   ``Zend\Validator\File\UploadFile`` validator.
 
 The biggest thing to be concerned about is that if you are using a ``<input type="file">`` element in your form,
 you will need to use the ``FileInput`` **instead of** ``Input`` or else you will encounter issues.
@@ -39,7 +39,7 @@ Usage of ``FileInput`` is essentially the same as ``Input``:
    // File upload input
    $file = new FileInput('file');           // Special File Input type
    $file->getValidatorChain()               // Validators are run first w/ FileInput
-        ->addValidator(new Validator\File\Upload());
+        ->addValidator(new Validator\File\UploadFile());
    $file->getFilterChain()                  // Filters are run second w/ FileInput
         ->attach(new Filter\File\RenameUpload(array(
             'target'    => './data/tmpuploads/file',

--- a/docs/languages/en/modules/zend.validator.file.rst
+++ b/docs/languages/en/modules/zend.validator.file.rst
@@ -26,7 +26,7 @@ such as file size validation and CRC checking.
 .. include:: zend.validator.file.not-exists.rst
 .. include:: zend.validator.file.sha1.rst
 .. include:: zend.validator.file.size.rst
-.. include:: zend.validator.file.upload.rst
+.. include:: zend.validator.file.upload-file.rst
 .. include:: zend.validator.file.word-count.rst
 
 

--- a/docs/languages/en/modules/zend.validator.file.upload-file.rst
+++ b/docs/languages/en/modules/zend.validator.file.upload-file.rst
@@ -1,9 +1,9 @@
-.. _zend.validator.file.upload:
+.. _zend.validator.file.upload-file:
 
-Upload
-------
+UploadFile
+----------
 
-``Zend\Validator\File\Upload`` checks whether a file has been uploaded via a form ``POST``
+``Zend\Validator\File\UploadFile`` checks whether a single file has been uploaded via a form ``POST``
 and will return descriptive messages for any upload errors.
 
 .. note::
@@ -11,7 +11,7 @@ and will return descriptive messages for any upload errors.
    :ref:`Zend\\InputFilter\\FileInput <zend.input-filter.file-input>` will automatically
    prepend this validator in it's validation chain.
 
-.. _zend.validator.file.upload.usage:
+.. _zend.validator.file.upload-file.usage:
 
 .. rubric:: Usage Examples
 
@@ -24,7 +24,7 @@ and will return descriptive messages for any upload errors.
    $files   = $request->getFiles();
    // i.e. $files['my-upload']['error'] == 0
 
-   $validator = \Zend\Validator\File\Upload();
+   $validator = \Zend\Validator\File\UploadFile();
    if ($validator->isValid($files['my-upload'])) {
        // file is valid
    }


### PR DESCRIPTION
Changes just before the 2.1 release caused the new Upload validator to be renamed to UploadFile. Updated docs.
