### PR TITLE
fix menu in index.rst

### DIFF
--- a/docs/languages/en/index.rst
+++ b/docs/languages/en/index.rst
@@ -244,7 +244,6 @@
    modules/zendservice.technorati
    modules/zendservice.twitter
    modules/zendservice.windows-azure
-   modules/zendtool.introduction
    ref/copyrights
 
 |IntroductiontoZendFramework|


### PR DESCRIPTION
zendtool menu should before zend di quickstart menu, not after windows-azure. it's redundant input.
