### PR TITLE
Update docs/languages/en/user-guide/unit-testing.rst

### DIFF
--- a/docs/languages/en/user-guide/unit-testing.rst
+++ b/docs/languages/en/user-guide/unit-testing.rst
@@ -131,25 +131,4 @@ this, then your application is ready for more tests!
 
     OK (1 test, 5 assertions)
 
-
-Test your console router
---------------------------
-
-Zend\Test component provide a HTTP controller tests case and a console controller. To test your application 
-with the console, just switch with the AbstractConsoleControllerTestCaseTest. Now, you can use the same methods 
-in your tests controllers :
-
-.. code-block:: php
-
-    public function testConsoleActionCanBeAccessed()
-    {
-        $this->dispatch('--your-arg');
-        $this->assertResponseStatusCode(0);
-
-        $this->assertModuleName('application');
-        $this->assertControllerName('application_console');
-        $this->assertControllerClass('ConsoleController');
-        $this->assertMatchedRouteName('myaction');
-    }
-
 More informations at the ``Zend\Test`` component documentation page.


### PR DESCRIPTION
**Remove Test your console router**

Since no Console Routes are setup in the [ZendSkeletonApplication config](https://github.com/zendframework/ZendSkeletonApplication/blob/master/module/Application/config/module.config.php) I would argue that this is confusing to the user to have this here. As if they add it to there Test it will produce failures.
