### PR TITLE
Update docs/languages/en/user-guide/routing-and-controllers.rst

### DIFF
--- a/docs/languages/en/user-guide/routing-and-controllers.rst
+++ b/docs/languages/en/user-guide/routing-and-controllers.rst
@@ -69,7 +69,7 @@ actions. This is the updated module config file with the new code highlighted.
                         'route'    => '/album[/:action][/:id]',
                         'constraints' => array(
                             'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                            'id'     => '[0-9]+',
+                            'id'     => '[0-9]*',
                         ),
                         'defaults' => array(
                             'controller' => 'Album\Controller\Album',


### PR DESCRIPTION
I changed the ID matching regex from [0-9]+ to [0-9]*.  This way, when a user requests album/edit without an id, it actually goes to the controller instead of a 404 page.
