### PR TITLE
Update docs/languages/en/modules/zend.mvc.controllers.rst

### DIFF
--- a/docs/languages/en/modules/zend.mvc.controllers.rst
+++ b/docs/languages/en/modules/zend.mvc.controllers.rst
@@ -240,7 +240,7 @@ The AbstractRestfulController
 -----------------------------
 
 The second abstract controller ZF2 provides is ``Zend\Mvc\Controller\AbstractRestfulController``. This controller
-provides a naive RESTful implementation that simply maps HTTP request methods to controller methods, using the
+provides a native RESTful implementation that simply maps HTTP request methods to controller methods, using the
 following matrix:
 
 - **GET** maps to either ``get()`` or ``getList()``, depending on whether or not an "id" parameter is found in the


### PR DESCRIPTION
fixed typo in AbstractRestfulController description 
