### PR TITLE
Adding service naming best practices

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.quick-start.rst
+++ b/docs/languages/en/modules/zend.service-manager.quick-start.rst
@@ -163,7 +163,7 @@ As such, you have a variety of ways to override service manager configuration se
 
 .. note::
 
-   ** Service names good practices**
+   **Service names good practices**
 
    When defining a new service, it is usually a good idea to use the fully qualified class name of the produced 
    instance or of one of the interfaces it implements as service name.


### PR DESCRIPTION
This PR adds the suggestion to use the FQCN of a class (or one of the interfaces it implements) as service name.
