### PR TITLE
Corrected spelling in the ZFTool documentation.

### DIFF
--- a/docs/languages/en/modules/zendtool.introduction.rst
+++ b/docs/languages/en/modules/zendtool.introduction.rst
@@ -3,7 +3,7 @@
 Zend Framework Tool (ZFTool)
 ============================
 
-`ZFTool`_ is an utility module for maintaining modular Zend Framework 2 applications.
+`ZFTool`_ is a utility module for maintaining modular Zend Framework 2 applications.
 It runs from the command line and can be installed as ZF2 module or as PHAR (see below).
 This tool gives you the ability to:
 


### PR DESCRIPTION
The first line of the introduction starts right off with a spelling error, it bothered me so I corrected the mistake.

See House M.D. (he's usually right):
http://answers.yahoo.com/question/index?qid=20070517154920AAABFVA
