### PR TITLE
Update Using Request Methods Other Than Get

### DIFF
--- a/docs/languages/en/modules/zend.http.client.rst
+++ b/docs/languages/en/modules/zend.http.client.rst
@@ -502,7 +502,8 @@ called, the default request method is ``GET`` (see the above example).
    use Zend\Http\Request;
 
    $request = new Request();
-   $client = new Client('http://example.org');
+   $request->setUri('http://example.org');
+   $client = new Client();
 
    // Performing a POST request
    $request->setMethod(Request::METHOD_POST);


### PR DESCRIPTION
The original example does not work, as setting the request object on the client resets the URI. Therefore, the URI must be set on the request object.

I don't know if this is the intended behaviour though, as it would make sense to me to reuse the URI if the request hasn't got one set.
