### PR TITLE
fix zend.mvc.intro : pass $config to ModuleManager

### DIFF
--- a/docs/languages/en/modules/zend.mvc.intro.rst
+++ b/docs/languages/en/modules/zend.mvc.intro.rst
@@ -224,7 +224,7 @@ These may be satisfied at instantiation:
 
    $serviceManager = new ServiceManager();
    $serviceManager->setService('EventManager', new EventManager());
-   $serviceManager->setService('ModuleManager', new ModuleManager());
+   $serviceManager->setService('ModuleManager', new ModuleManager($config));
    $serviceManager->setService('Request', new PhpEnvironment\Request());
    $serviceManager->setService('Response', new PhpEnvironment\Response());
 


### PR DESCRIPTION
Fix #792
