### PR TITLE
code block doesn't show up

### DIFF
--- a/docs/languages/en/tutorials/unittesting.rst
+++ b/docs/languages/en/tutorials/unittesting.rst
@@ -345,8 +345,6 @@ Here is how we can accomplish this, by modifying the ``testIndexActionCanBeAcces
 test method as follows:
 
 .. code-block:: php
-    :linenos:
-    :emphasize-lines: 3-13
 
     public function testIndexActionCanBeAccessed()
     {


### PR DESCRIPTION
I can't make the code block show with :linenos: and :emphasize-lines: enabled.
