### PR TITLE
Update zend.view.helpers.head-script.rst

### DIFF
--- a/docs/languages/en/modules/zend.view.helpers.head-script.rst
+++ b/docs/languages/en/modules/zend.view.helpers.head-script.rst
@@ -61,7 +61,7 @@ you wish to use in the element.
 
    .. _zend.view.helpers.initial.headscript.noescape:
 
-   .. rubric:: Create an jQuery template with the headScript
+   .. rubric:: Create a jQuery template with the headScript
 
    .. code-block:: php
       :linenos:
@@ -71,7 +71,7 @@ you wish to use in the element.
       $this->headScript()->appendScript(
           $template,
           'text/x-jquery-tmpl',
-          array('id='tmpl-book', 'noescape' => true)
+          array('id' => 'tmpl-book', 'noescape' => true)
       );
 
 


### PR DESCRIPTION
fixed grammatical error and a syntax error in the jQuery example.
