### PR TITLE
Documentation for Abstract Factories introduced in 2.2.0

### DIFF
--- a/docs/languages/en/modules/zend.mvc.services.rst
+++ b/docs/languages/en/modules/zend.mvc.services.rst
@@ -153,10 +153,10 @@ services configured out of the box.
     ``Zend\Mvc\Service\DiStrictAbstractServiceFactoryFactory`` injecting the ``Di`` service
     instance.
 
-  - ``EventManager``, mapping to ``Zend\Mvc\Service\EventManagerFactory``. This factory composes a
-    shared reference to a ``SharedEventManager``, which is injected in a new ``EventManager``
-    instance. This service is not shared by default, allowing the ability to have an
-    ``EventManager`` per service, with a shared ``SharedEventManager`` injected in each.
+  - ``EventManager``, mapping to ``Zend\Mvc\Service\EventManagerFactory``. This factory returns a
+    new instance of ``Zend\EventManager\EventManager`` on each request.  This service is not shared
+    by default, allowing the ability to have an ``EventManager`` per service, with a shared
+    ``SharedEventManager`` injected in each.
 
   - ``FilterManager``, mapping to ``Zend\Mvc\Service\FilterManagerFactory``. This instantiates the
     ``Zend\Filter\FilterPluginManager`` instance, passing it the service manager instance -- this is


### PR DESCRIPTION
This PR provides documentation for the abstract factories introduced in 2.2.0, and also ensures the list of services is up-to-date with current master.

I've also added small sections for:
- covering the various service types
- highlighting the available plugin managers registered by default.
