### PR TITLE
saveAlbum() accepts Album class, not an array

### DIFF
--- a/docs/languages/en/user-guide/forms-and-actions.rst
+++ b/docs/languages/en/user-guide/forms-and-actions.rst
@@ -358,7 +358,7 @@ This time we use ``editAction()`` in the ``AlbumController``:
                 $form->setData($request->getPost());
 
                 if ($form->isValid()) {
-                    $this->getAlbumTable()->saveAlbum($form->getData());
+                    $this->getAlbumTable()->saveAlbum($album);
 
                     // Redirect to list of albums
                     return $this->redirect()->toRoute('album');


### PR DESCRIPTION
`AlbumTable`'s method `saveAlbum()` has an `Album`-type parameter. not an array
