### PR TITLE
Update Zend\ServiceManager service factory example to match code

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.intro.rst
+++ b/docs/languages/en/modules/zend.service-manager.intro.rst
@@ -55,7 +55,7 @@ In addition to the above described methods, the ``ServiceManager`` provides addi
 
      class MyFactory implements FactoryInterface
      {
-         public function createService()
+         public function createService(ServiceLocatorInterface $serviceLocator)
          {
              return new \stdClass();
          }


### PR DESCRIPTION
`Zend\ServiceManager\FactoryInterface::createService` takes a service locator argument
