### PR TITLE
Exception is for Album, not Form

### DIFF
--- a/docs/languages/en/user-guide/database-and-models.rst
+++ b/docs/languages/en/user-guide/database-and-models.rst
@@ -136,7 +136,7 @@ Next, we create our ``AlbumTable.php`` file in ``module/Album/src/Album/Model`` 
                 if ($this->getAlbum($id)) {
                     $this->tableGateway->update($data, array('id' => $id));
                 } else {
-                    throw new \Exception('Form id does not exist');
+                    throw new \Exception('Album id does not exist');
                 }
             }
         }


### PR DESCRIPTION
Within `docs/languages/en/user-guide/database-and-models.rst`, the exception thrown at commit should be concerning an Album, not a Form.
