### PR TITLE
Better Quick-Start example for zend.cache.storage.adapter

### DIFF
--- a/docs/languages/en/modules/zend.cache.storage.adapter.rst
+++ b/docs/languages/en/modules/zend.cache.storage.adapter.rst
@@ -51,14 +51,17 @@ Quick Start
 
    // Via factory:
    $cache = StorageFactory::factory(array(
-       'adapter' => 'apc',
+       'adapter' => array(
+           'name'    => 'apc',
+           'options' => array('ttl' => 3600),
+       ),
        'plugins' => array(
            'exception_handler' => array('throw_exceptions' => false),
        ),
    ));
 
    // Alternately:
-   $cache  = StorageFactory::adapterFactory('apc');
+   $cache  = StorageFactory::adapterFactory('apc', array('ttl' => 3600));
    $plugin = StorageFactory::pluginFactory('exception_handler', array(
        'throw_exceptions' => false,
    ));
@@ -66,9 +69,10 @@ Quick Start
 
    // Or manually:
    $cache  = new Zend\Cache\Storage\Adapter\Apc();
-   $plugin = new Zend\Cache\Storage\Plugin\ExceptionHandler(array(
-       'throw_exceptions' => false,
-   ));
+   $cache->getOptions()->setTtl(3600);
+   
+   $plugin = new Zend\Cache\Storage\Plugin\ExceptionHandler();
+   $plugin->getOptions()->setThrowExceptions(false);
    $cache->addPlugin($plugin);
 
 


### PR DESCRIPTION
This updates the Quck-Start examples initializing a cache storage adapter.

Now configuration will be passed in complete mode (no shortcuts) to make it better portable to other adapters.
Now it follows 100% interfaces which don't contain passing options as constructor argument.

see zendframework/zf2#4779
