### PR TITLE
typo bar/baz in Abstract factories example

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.intro.rst
+++ b/docs/languages/en/modules/zend.service-manager.intro.rst
@@ -121,7 +121,7 @@ In addition to the above described methods, the ``ServiceManager`` provides addi
 
      var_dump($serviceManager->get('foo')->name); // foo
      var_dump($serviceManager->get('bar')->name); // bar
-     var_dump($serviceManager->get('bar')->name); // exception! Zend\ServiceManager\Exception\ServiceNotFoundException
+     var_dump($serviceManager->get('baz')->name); // exception! Zend\ServiceManager\Exception\ServiceNotFoundException
 
 - **Initializers**. You may want certain injection points to be always called. As an example,
   any object you load via the service manager that implements


### PR DESCRIPTION
canCreateServiceWithName "knows" about foo and bar, but not about baz.
