### PR TITLE
Update package repository protocol

### DIFF
--- a/docs/languages/en/user-guide/skeleton-application.rst
+++ b/docs/languages/en/user-guide/skeleton-application.rst
@@ -10,7 +10,7 @@ to create a new project from scratch with Zend Framework:
 
 .. code-block:: bash
 
-    php composer.phar create-project --repository-url="http://packages.zendframework.com" -s dev zendframework/skeleton-application path/to/install
+    php composer.phar create-project --repository-url="https://packages.zendframework.com" -s dev zendframework/skeleton-application path/to/install
 
 .. note::
 


### PR DESCRIPTION
http://packages.zendframework.com redirects to https://packages.zendframework.com which causes composer to fail. (it doesn't follow the redirect and try to parse the HTML returned.)
