### PR TITLE
Update zend.i18n.translating.rst

### DIFF
--- a/docs/languages/en/modules/zend.i18n.translating.rst
+++ b/docs/languages/en/modules/zend.i18n.translating.rst
@@ -67,9 +67,7 @@ The translator supports the following major translation formats:
 
 - Gettext
 
-- Tmx
-
-- Xliff
+- INI
 
 .. _zend.i18n.translating.setting-a-locale:
 


### PR DESCRIPTION
Removed TMX and Xliff as ZF2 does not support these types. Added missing INI support.
