### PR TITLE
Fixed example `Generating a formatted HTTP Request from a Request object...

### DIFF
--- a/docs/languages/en/modules/zend.http.request.rst
+++ b/docs/languages/en/modules/zend.http.request.rst
@@ -474,6 +474,7 @@ Examples
        'HeaderField2' => 'header-field-value2',
    ));
    $request->getPost()->set('foo', 'bar');
+   $request->setContent($request->getPost()->toString());
    echo $request->toString();
 
    /** Will produce:


### PR DESCRIPTION
Putting requests post data into requests content. `$request->toString()` returns now the expected output with post parameters. Probably fixes issue #3305.
