### PR TITLE
change emphasize-lines number on modules.rst on registering Album module

### DIFF
--- a/docs/languages/en/user-guide/modules.rst
+++ b/docs/languages/en/user-guide/modules.rst
@@ -169,7 +169,7 @@ skeleton application. Update this file so that its ``modules`` section contains 
 
 .. code-block:: php
    :linenos:
-   :emphasize-lines: 5
+   :emphasize-lines: 4
 
     return array(
         'modules' => array(


### PR DESCRIPTION
The emphasize-lines should before it ( on the  // <-- Add this line line number )
![line-should-be-on-number-4](https://f.cloud.github.com/assets/459648/1103938/9b219f7a-18d1-11e3-8689-00e67e273ea1.png)
