### PR TITLE
Minor fix in RewriteCond and RewriteRules to perform a faster match and fix a glitch in caching rules

### DIFF
--- a/docs/languages/de/modules/zend.cache.backends.rst
+++ b/docs/languages/de/modules/zend.cache.backends.rst
@@ -262,24 +262,24 @@ Behandlung benötigen um einen korrekten Content-Type Header zu schicken:
    RewriteEngine On
 
    RewriteCond %{REQUEST_URI} feed/rss$
-   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.xml -f
-   RewriteRule .* cached/%{REQUEST_URI}.xml [L,T=application/rss+xml]
+   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.xml -f
+   RewriteRule ^ cached/%{REQUEST_URI}.xml [L,T=application/rss+xml]
 
    RewriteCond %{REQUEST_URI} feed/atom$
-   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.xml -f
-   RewriteRule .* cached/%{REQUEST_URI}.xml [L,T=application/atom+xml]
+   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.xml -f
+   RewriteRule ^ cached/%{REQUEST_URI}.xml [L,T=application/atom+xml]
 
-   RewriteCond %{DOCUMENT_ROOT}/cached/index.html -f
+   RewriteCond %{DOCUMENT_ROOT}/cached/index\.html -f
    RewriteRule ^/*$ cached/index.html [L]
-   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.(html|xml|json|opml|svg) -f
-   RewriteRule .* cached/%{REQUEST_URI}.%1 [L]
+   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.(html|xml|json|opml|svg) -f
+   RewriteRule ^ cached/%{REQUEST_URI}.%1 [L]
 
    RewriteCond %{REQUEST_FILENAME} -s [OR]
    RewriteCond %{REQUEST_FILENAME} -l [OR]
    RewriteCond %{REQUEST_FILENAME} -d
-   RewriteRule ^.*$ - [NC,L]
+   RewriteRule ^ - [NC,L]
 
-   RewriteRule ^.*$ index.php [NC,L]
+   RewriteRule ^ index.php [NC,L]
 
 Das obenstehende nimmt an das statische Dateien im Verzeichnis ``./public/cached`` gecacht werden. Wir betrachten
 die Einstellung dieses Ortes unter "public_dir" weiter unten.

--- a/docs/languages/de/ref/project.structure.rst
+++ b/docs/languages/de/ref/project.structure.rst
@@ -215,8 +215,8 @@ Hier ist eine sehr grundsätzliche Definition eines virtuellen Hosts. Diese Rege
            RewriteCond %{REQUEST_FILENAME} -s [OR]
            RewriteCond %{REQUEST_FILENAME} -l [OR]
            RewriteCond %{REQUEST_FILENAME} -d
-           RewriteRule ^.*$ - [NC,L]
-           RewriteRule ^.*$ /index.php [NC,L]
+           RewriteRule ^ - [NC,L]
+           RewriteRule ^ /index.php [NC,L]
        </Location>
    </VirtualHost>
 
@@ -239,8 +239,8 @@ für virtuelle Hosts, ausser das Sie nur die Rewrite Regeln spezifiziert, und de
    RewriteCond %{REQUEST_FILENAME} -s [OR]
    RewriteCond %{REQUEST_FILENAME} -l [OR]
    RewriteCond %{REQUEST_FILENAME} -d
-   RewriteRule ^.*$ - [NC,L]
-   RewriteRule ^.*$ index.php [NC,L]
+   RewriteRule ^ - [NC,L]
+   RewriteRule ^ index.php [NC,L]
 
 Es gibt viele Wege um ``mod_rewrite`` zu konfigurieren; wenn man weitere Informationen haben will, dann sollte man
 in Jayson Minard's `Blueprint for PHP Applications: Bootstrapping`_ sehen.

--- a/docs/languages/en/migration/zf1_zf2_parallel.rst
+++ b/docs/languages/en/migration/zf1_zf2_parallel.rst
@@ -109,9 +109,9 @@ the instructions in the note below):
    RewriteCond %{REQUEST_FILENAME} -s [OR]
    RewriteCond %{REQUEST_FILENAME} -l [OR]
    RewriteCond %{REQUEST_FILENAME} -d
-   RewriteRule ^.*$ - [NC,L]
+   RewriteRule ^ - [NC,L]
    RewriteRule ^album(/.*)?$ index_zf2.php [NC,L]
-   RewriteRule ^.*$ index.php [NC,L]
+   RewriteRule ^ index.php [NC,L]
 
 ``index_zf2.php`` is a PHP script that includes as the typical
 ``public/index.php`` file of ZF2.  Here is the source code for

--- a/docs/languages/en/ref/project.structure.rst
+++ b/docs/languages/en/ref/project.structure.rst
@@ -201,8 +201,8 @@ matching file is found under the ``document_root``.
            RewriteCond %{REQUEST_FILENAME} -s [OR]
            RewriteCond %{REQUEST_FILENAME} -l [OR]
            RewriteCond %{REQUEST_FILENAME} -d
-           RewriteRule ^.*$ - [NC,L]
-           RewriteRule ^.*$ /index.php [NC,L]
+           RewriteRule ^ - [NC,L]
+           RewriteRule ^ /index.php [NC,L]
        </Location>
    </VirtualHost>
 
@@ -224,8 +224,8 @@ configuration, except that it specifies only the rewrite rules, and the leading 
    RewriteCond %{REQUEST_FILENAME} -s [OR]
    RewriteCond %{REQUEST_FILENAME} -l [OR]
    RewriteCond %{REQUEST_FILENAME} -d
-   RewriteRule ^.*$ - [NC,L]
-   RewriteRule ^.*$ index.php [NC,L]
+   RewriteRule ^ - [NC,L]
+   RewriteRule ^ index.php [NC,L]
 
 There are many ways to configure ``mod_rewrite``; if you would like more information, see Jayson Minard's
 `Blueprint for PHP Applications: Bootstrapping`_.

--- a/docs/languages/en/user-guide/skeleton-application.rst
+++ b/docs/languages/en/user-guide/skeleton-application.rst
@@ -140,7 +140,7 @@ before continuing.  If you're are using IIS with the URL Rewrite Module, import 
    :linenos:
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^.*$ index.php [NC,L]
+    RewriteRule ^ index.php [NC,L]
 
 You now have a working skeleton application and we can start adding the specifics
 for our application.

--- a/docs/languages/fr/modules/zend.cache.backends.rst
+++ b/docs/languages/fr/modules/zend.cache.backends.rst
@@ -260,24 +260,24 @@ some content, including two specific feeds which need additional treatment to se
    RewriteEngine On
 
    RewriteCond %{REQUEST_URI} feed/rss$
-   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.xml -f
-   RewriteRule .* cached/%{REQUEST_URI}.xml [L,T=application/rss+xml]
+   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.xml -f
+   RewriteRule ^ cached/%{REQUEST_URI}.xml [L,T=application/rss+xml]
 
    RewriteCond %{REQUEST_URI} feed/atom$
-   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.xml -f
-   RewriteRule .* cached/%{REQUEST_URI}.xml [L,T=application/atom+xml]
+   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.xml -f
+   RewriteRule ^ cached/%{REQUEST_URI}.xml [L,T=application/atom+xml]
 
    RewriteCond %{DOCUMENT_ROOT}/cached/index.html -f
    RewriteRule ^/*$ cached/index.html [L]
-   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.(html|xml|json|opml|svg) -f
-   RewriteRule .* cached/%{REQUEST_URI}.%1 [L]
+   RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.(html|xml|json|opml|svg) -f
+   RewriteRule ^ cached/%{REQUEST_URI}.%1 [L]
 
    RewriteCond %{REQUEST_FILENAME} -s [OR]
    RewriteCond %{REQUEST_FILENAME} -l [OR]
    RewriteCond %{REQUEST_FILENAME} -d
-   RewriteRule ^.*$ - [NC,L]
+   RewriteRule ^ - [NC,L]
 
-   RewriteRule ^.*$ index.php [NC,L]
+   RewriteRule ^ index.php [NC,L]
 
 The above assumes static files are cached to the directory ``./public/cached``. We'll cover the option setting this
 location, "public_dir", below.

--- a/docs/languages/fr/user-guide/skeleton-application.rst
+++ b/docs/languages/fr/user-guide/skeleton-application.rst
@@ -134,7 +134,7 @@ Rewrite Module, importez les lignes suivantes:
 .. code-block:: apache
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^.*$ index.php [NC,L]
+    RewriteRule ^ index.php [NC,L]
 
 Vous avez maintenant une application de base en état de marche et nous pouvons
 commencer à ajouter les spécificités de notre application.

--- a/docs/languages/pt/user-guide/skeleton-application.rst
+++ b/docs/languages/pt/user-guide/skeleton-application.rst
@@ -127,7 +127,7 @@ antes de continuar.  Se estiver usando IIS com o módulo URL Rewrite utilize o s
 .. code-block:: apache
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^.*$ index.php [NC,L]
+    RewriteRule ^ index.php [NC,L]
 
 Você agora tem sua Skeleton Application funcionando e pode começar a desenvolver sua aplicação.
 

--- a/docs/languages/tr/user-guide/skeleton-application.rst
+++ b/docs/languages/tr/user-guide/skeleton-application.rst
@@ -117,7 +117,7 @@ aşağıdakini ekleyin:
 .. code-block:: apache
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^.*$ index.php [NC,L]
+    RewriteRule ^ index.php [NC,L]
 
 Artık çalışan bir iskelet uygulamaya sahipsiniz ve uygulamamız için özellikleri
 eklemeye başlayabiliriz.


### PR DESCRIPTION
If the match of '^.*$' is not used, it can be replaced with the regex
rule '^', witch means, 'match every string that starts'. This is
always the case.
This will gain some sub milliseconds performance increase because
the regex matching is faster.

Also fixed a possible glicht when looking for a cached file:
E.g.:
## Old

`RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}.(html|xml|json|opml|svg) -f`
## Fix

`RewriteCond %{DOCUMENT_ROOT}/cached/%{REQUEST_URI}\.(html|xml|json|opml|svg) -f`

In the old version, the '.' was not escaped. This could lead to a
wrong lookup of the file, because the dot can be any character.

REQUEST_URI=glitch-json
-> %{DOCUMENT_ROOT}/cache/glitch-json as file exists, but %{DOCUMENT_ROOT}/cache/glitch.json
-> The file http://mydomain.tld/cache/glitch.json is returned, witch
ends up in a 404 error
This case is very rare, but possible.
