### PR TITLE
Update zend.permissions.acl.intro.rst to show how to use string in addRole($role) for $role

### DIFF
--- a/docs/languages/en/modules/zend.permissions.acl.intro.rst
+++ b/docs/languages/en/modules/zend.permissions.acl.intro.rst
@@ -193,6 +193,17 @@ For this example, ``Zend\Permissions\Acl\Role\GenericRole`` is used, but any obj
    // Administrator does not inherit access controls
    $acl->addRole(new Role('administrator'));
 
+   /*
+   # This example could also be called without instantiating the roles.
+   # This will still use Zend\Permissions\Acl\Role\GenericRole.
+   $acl = new Acl();
+
+   $acl->addRole('guest')
+       ->addRole('staff', 'guest');
+       ->addRole('editor', 'staff');
+       ->addRole('administrator');
+   */
+
 .. _zend.permissions.acl.introduction.defining:
 
 Defining Access Controls


### PR DESCRIPTION
Updating documentation to reflect features:

https://github.com/zendframework/zf2/pull/5184
