### PR TITLE
missing closing quotation at line 39

### DIFF
--- a/docs/languages/en/modules/zend.form.element.url.rst
+++ b/docs/languages/en/modules/zend.form.element.url.rst
@@ -36,7 +36,7 @@ Here is the same example using the array notation:
     $form->add(array(
     	'type' => 'Zend\Form\Element\Url',
     	'name' => 'webpage-url',
-    	'options => array(
+    	'options' => array(
     		'label' => 'Webpage URL'
     	)
     ));


### PR DESCRIPTION
$form->add(array(
        'type' => 'Zend\Form\Element\Url',
        'name' => 'webpage-url',
        'options' => array(
            'label' => 'Webpage URL'
        )
    ));
