### PR TITLE
Comma in join() php block was in the wrong place.

### DIFF
--- a/docs/languages/en/modules/zend.db.sql.rst
+++ b/docs/languages/en/modules/zend.db.sql.rst
@@ -180,7 +180,7 @@ join():
    :linenos:
 
    $select->join(
-   	'foo' // table name,
+   	'foo', // table name
    	'id = bar.id', // expression to join on (will be quoted by platform object before insertion),
    	array('bar', 'baz'), // (optional) list of columns, same requirements as columns() above
    	$select::JOIN_OUTER // (optional), one of inner, outer, left, right also represented by constants in the API


### PR DESCRIPTION
Comma placed after // would get commented out, put comma before comment
