### PR TITLE
Fixed the scrypt note about new pecl extension

### DIFF
--- a/docs/languages/en/modules/zend.crypt.key.derivation.rst
+++ b/docs/languages/en/modules/zend.crypt.key.derivation.rst
@@ -133,10 +133,9 @@ Below is reported a usage example of the ``Scrypt`` adapter.
    algorithm, the more secure the derived key will be.
    Unfortunately a pure PHP implementation of the scrypt algorithm is very slow compared with
    the C implementation (this is always true, if you compare execution time of C with PHP).
-   If you want use a faster scrypt algorithm we suggest to use the C implementation of scrypt,
-   supported by this `Scrypt extension for PHP`_ (please note that this PHP extension is not
-   officially supported by `php.net`_). The Scrypt adapter of Zend Framework is able to recognize
-   if this extension is loaded and use it instead of the pure PHP implementation.
+   If you want use a faster scrypt algorithm we suggest to install the `scrypt PECL`_ extension.
+   The Scrypt adapter of Zend Framework is able to recognize if the PECL extension is loaded and use it
+   instead of the pure PHP implementation.
 
 .. _`base64_encode()`: http://php.net/manual/en/function.base64-encode.php
 .. _`bin2hex()`: http://php.net/manual/en/function.bin2hex.php
@@ -148,4 +147,5 @@ Below is reported a usage example of the ``Scrypt`` adapter.
 .. _`bcrypt`: http://en.wikipedia.org/wiki/Bcrypt
 .. _`Scrypt extension for PHP`: https://github.com/DomBlack/php-scrypt
 .. _`php.net`: http://www.php.net
+.. _`scrypt PECL`: http://pecl.php.net/package/scrypt 
 .. [#f1] See Colin Percival's slides on scrypt from BSDCan'09: http://www.tarsnap.com/scrypt/scrypt-slides.pdf


### PR DESCRIPTION
Fixed the note about scrypt adding the new PECL scrypt extension: http://pecl.php.net/package/scrypt.
See the comment here: http://framework.zend.com/manual/2.2/en/modules/zend.crypt.key.derivation.html#comment-1067404542
