### PR TITLE
CS fix to match PSR2

### DIFF
--- a/docs/languages/en/tutorials/unittesting.rst
+++ b/docs/languages/en/tutorials/unittesting.rst
@@ -180,7 +180,9 @@ And a file called ``Bootstrap.php``, also under ``zf2-tutorial/module/Album/test
             $previousDir = '.';
             while (!is_dir($dir . '/' . $path)) {
                 $dir = dirname($dir);
-                if ($previousDir === $dir) return false;
+                if ($previousDir === $dir) {
+                    return false;
+                }
                 $previousDir = $dir;
             }
             return $dir . '/' . $path;


### PR DESCRIPTION
"The body of each structure MUST be enclosed by braces. This standardizes
how the structures look, and reduces the likelihood of introducing errors
as new lines get added to the body." - https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#5-control-structures
