### PR TITLE
Fixed missing use statement in code example

### DIFF
--- a/docs/languages/en/modules/zend.console.introduction.rst
+++ b/docs/languages/en/modules/zend.console.introduction.rst
@@ -204,6 +204,7 @@ Let's modify our ``Application\Module`` to provide usage info:
 
     namespace Application;
 
+    use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
     use Zend\ModuleManager\Feature\ConfigProviderInterface;
     use Zend\ModuleManager\Feature\ConsoleUsageProviderInterface;
     use Zend\Console\Adapter\AdapterInterface as Console;


### PR DESCRIPTION
Update zend.console.introduction.rst
