### PR TITLE
Update zend.service-manager.intro.rst Initializers section

### DIFF
--- a/docs/languages/en/modules/zend.service-manager.intro.rst
+++ b/docs/languages/en/modules/zend.service-manager.intro.rst
@@ -151,6 +151,7 @@ In addition to the above described methods, the ``ServiceManager`` provides addi
          }
      }
 
+     $serviceManager->addInitializer('MyInitializer');
      $serviceManager->setInvokableClass('my-service', 'stdClass');
 
      var_dump($serviceManager->get('my-service')->initialized); // initialized!


### PR DESCRIPTION
We must call addInitializer method to initialize \stdClass->initialized.
