### PR TITLE
Pygments startinline parameter can't be passed from Sphinx code-block

### DIFF
--- a/docs/languages/en/tutorials/tutorial.eventmanager.rst
+++ b/docs/languages/en/tutorials/tutorial.eventmanager.rst
@@ -228,7 +228,6 @@ At any point, if you do not want to notify shared listeners, pass a ``null``
 value to ``setSharedManager()``:
 
 .. code-block:: php
-    :startinline: true
 
     $events->setSharedManager(null);
 
@@ -236,7 +235,6 @@ and they will be ignored. If at any point, you want to enable them again, pass
 the ``SharedEventManager`` instance:
 
 .. code-block:: php
-    :startinline: true
 
     $events->setSharedManager($sharedEvents);
 
@@ -371,7 +369,6 @@ As an example:
 You can attach this using either ``attach()`` or ``attachAggregate()``:
 
 .. code-block:: php
-    :startinline: true
 
     $logListener = new LogEvents($logger);
 


### PR DESCRIPTION
> The Pygments PHP lexer requires PHP code to be between "<?php" "?>"
> delimiters. You can override this with the "startinline" option, but
> there is currently no way to pass Pygments lexer options from Sphinx.
> 
> The following hack should work though (put it in conf.py):
> 
> from sphinx.highlighting import lexers
> from pygments.lexers.web import PhpLexer
> lexers['php'] = PhpLexer(startinline=True)"

http://osdir.com/ml/sphinx-dev/2010-04/msg00022.html
