### PR TITLE
Fix *snippets.rst duplicate inclusion by conf.py & sphinx-build sourcedir

### DIFF
--- a/docs/languages/en/conf.py
+++ b/docs/languages/en/conf.py
@@ -64,7 +64,7 @@ release = '2.2.5dev'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', '*snippets.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION
This fixes the `*snippets.rst` files from being included more than once from the `conf.py` `rst_epilog` variable and the `sphinx-build` source directory. The following error can be seen in previous build outputs:

> snippets.rst:4: ERROR: Duplicate substitution definition name: "ProgrammersReferenceGuideofZendFramework2".
> snippets.rst:6: ERROR: Duplicate substitution definition name: "IntroductiontoZendFramework".
> snippets.rst:8: ERROR: Duplicate substitution definition name: "UserGuide".
> snippets.rst:10: ERROR: Duplicate substitution definition name: "UserGuideIntroduction".
> snippets.rst:14: ERROR: Duplicate substitution definition name: "LearningZendFramework".
> snippets.rst:16: ERROR: Duplicate substitution definition name: "Migration".
> snippets.rst:18: ERROR: Duplicate substitution definition name: "ZendFrameworkReference".
> snippets.rst:20: ERROR: Duplicate substitution definition name: "ZendServiceReference".
> snippets.rst:22: ERROR: Duplicate substitution definition name: "IndicesAndTables".
> snippets.rst:24: ERROR: Duplicate substitution definition name: "ZFTool".

By excluding `*snippets.rst` from the source directory, it is only included once by the `conf.py` `rst_epilog` variable as intended.

You may confirm that the above errors no longer exist from the Travis-ci build details link and that the documentation still renders as expected: http://webdevelzf2-documentation.readthedocs.org/en/latest/.
