### PR TITLE
Fix rubric directive typo in modules/zend.filter.uri-normalize.rst

### DIFF
--- a/docs/languages/en/modules/zend.filter.uri-normalize.rst
+++ b/docs/languages/en/modules/zend.filter.uri-normalize.rst
@@ -8,7 +8,7 @@ scheme will not be affected, even if a different scheme is enforced.
 
 .. _zend.filter.set.uri-normalize.options:
 
-.. rubrice:: Supported Options
+.. rubric:: Supported Options
 
 The following options are supported for ``Zend\Filter\UriNormalize``:
 


### PR DESCRIPTION
This fixes a `reST` `rubric` directive typo in `modules/zend.filter.uri-normalize.rst`. The following error can be seen in previous build outputs:

> modules/zend.filter.uri-normalize.rst:11: ERROR: Unknown directive type "rubrice".

You may confirm that the above errors no longer exist from the Travis-ci build details link below and the [build log](https://s3.amazonaws.com/archive.travis-ci.org/jobs/12473243/log.txt) and that the documentation still renders as expected: http://webdevelzf2-documentation.readthedocs.org/en/latest/.
