### PR TITLE
Fix broken reference from unexpected indentation

### DIFF
--- a/docs/languages/en/modules/zend.module-manager.module-class.rst
+++ b/docs/languages/en/modules/zend.module-manager.module-class.rst
@@ -78,9 +78,9 @@ The following example shows a more typical usage of the ``Module`` class:
    }
 
 For a list of the provided module manager listeners and the interfaces and methods that ``Module`` classes may
-implement in order to interact with the module manager and application, see the :ref:`module manager listeners
- <zend.module-manager.module-manager.module-manager-listeners>` and the :ref:`module mananger events
- <zend.module-manager.module-manager.module-manager-events>` documentations.
+implement in order to interact with the module manager and application, see the :ref:`module manager
+listeners <zend.module-manager.module-manager.module-manager-listeners>` and the :ref:`module mananger
+events <zend.module-manager.module-manager.module-manager-events>` documentations.
 
 .. _zend.module-manager.module-class.the-loadModules.post-event:
 


### PR DESCRIPTION
This fixes broken references in `modules/zend.module-manager.module-class.rst`. The following error can be seen in previous build outputs:

> zend.module-manager.module-class.rst:82: ERROR: Unexpected indentation
