### PR TITLE
Fix ordered list spacing in modules/zend.navigation.view.helper.sitemap.rst

### DIFF
--- a/docs/languages/en/modules/zend.navigation.view.helper.sitemap.rst
+++ b/docs/languages/en/modules/zend.navigation.view.helper.sitemap.rst
@@ -273,6 +273,7 @@ Render the sitemap using a maximum depth of 1.
 
    By default, Zend Framework uses *UTF-8* as its default encoding, and, specific to this case, ``Zend\View`` does
    as well. So if you want to use another encoding with ``Sitemap``, you will have do three things:
+
       1. Create a custom renderer and implement a ``getEncoding()`` method;
       2. Create a custom rendering strategy that will return an instance of your custom renderer;
       3. Attach the custom strategy in the ``ViewEvent``;


### PR DESCRIPTION
This fixes ordered list spacing in `modules/zend.navigation.view.helper.sitemap.rst`. The following error can be seen in previous build outputs:

> modules/zend.navigation.view.helper.sitemap.rst:276: ERROR: Unexpected indentation
