### PR TITLE
adding missing CSS class for navigation container

### DIFF
--- a/docs/languages/en/tutorials/tutorial.navigation.rst
+++ b/docs/languages/en/tutorials/tutorial.navigation.rst
@@ -152,7 +152,7 @@ just a few tweaks however, we can make it look awesome:
               ->menu()
               ->setMinDepth(0)
               ->setMaxDepth(0)
-              ->setUlClass('nav');
+              ->setUlClass('nav navbar-nav');
     ?>
 
 Here we tell the renderer to give the root UL the class of 'nav' so that


### PR DESCRIPTION
Replaced static menu's ul has 'navbar-nav' class, but replaced version generated with navigation helper doesn't. Without it looks ugly.
