### PR TITLE
Fix user-guide/routing-and-controllers.rst broken links and table

### DIFF
--- a/docs/languages/en/user-guide/routing-and-controllers.rst
+++ b/docs/languages/en/user-guide/routing-and-controllers.rst
@@ -169,17 +169,17 @@ Let’s go ahead and create our controller class ``AlbumController.php`` at ``zf
 We have now set up the four actions that we want to use. They won’t work yet
 until we set up the views. The URLs for each action are:
 
-+--------------------------------------------+----------------------------------------------------+
-| URL                                        | Method called                                      |
-+============================================+====================================================+
-| http://zf2-tutorial.localhost/album        | ``Album\Controller\AlbumController::indexAction``  |
-+--------------------------------------------+----------------------------------------------------+
-| http://zf2-tutorial.localhost/album/add    | ``Album\Controller\AlbumController::addAction``    |
-+--------------------------------------------+----------------------------------------------------+
-| http://zf2-tutorial.localhost/album/edit   | ``Album\Controller\AlbumController::editAction``   |
-+--------------------------------------------+----------------------------------------------------+
-| http://zf2-tutorial.localhost/album/delete | ``Album\Controller\AlbumController::deleteAction`` |
-+--------------------------------------------+----------------------------------------------------+
++------------------------------------------------+----------------------------------------------------+
+| URL                                            | Method called                                      |
++================================================+====================================================+
+| ``http://zf2-tutorial.localhost/album``        | ``Album\Controller\AlbumController::indexAction``  |
++------------------------------------------------+----------------------------------------------------+
+| ``http://zf2-tutorial.localhost/album/add``    | ``Album\Controller\AlbumController::addAction``    |
++------------------------------------------------+----------------------------------------------------+
+| ``http://zf2-tutorial.localhost/album/edit``   | ``Album\Controller\AlbumController::editAction``   |
++------------------------------------------------+----------------------------------------------------+
+| ``http://zf2-tutorial.localhost/album/delete`` | ``Album\Controller\AlbumController::deleteAction`` |
++------------------------------------------------+----------------------------------------------------+
 
 We now have a working router and the actions are set up for each page of our
 application.


### PR DESCRIPTION
Fix broken links and table as seen in `make linkcheck` output:

> user-guide/routing-and-controllers.rst:175: [broken] http://zf2-tutorial.localhost/album: <urlopen error [Errno -2] Name or service not known>
> user-guide/routing-and-controllers.rst:177: [broken] http://zf2-tutorial.localhost/album/add: <urlopen error [Errno -2] Name or service not known>
> user-guide/routing-and-controllers.rst:179: [broken] http://zf2-tutorial.localhost/album/edit: <urlopen error [Errno -2] Name or service not known>
> user-guide/routing-and-controllers.rst:181: [broken] http://zf2-tutorial.localhost/album/delete: <urlopen error [Errno -2] Name or service not known>
