### PR TITLE
Fix user-guide/forms-and-actions.rst broken link

### DIFF
--- a/docs/languages/en/user-guide/forms-and-actions.rst
+++ b/docs/languages/en/user-guide/forms-and-actions.rst
@@ -588,7 +588,7 @@ value when doing the deletion.
 Ensuring that the home page displays the list of albums
 -------------------------------------------------------
 
-One final point. At the moment, the home page, http://zf2-tutorial.localhost/
+One final point. At the moment, the home page, ``http://zf2-tutorial.localhost/``
 doesn’t display the list of albums.
 
 This is due to a route set up in the ``Application`` module’s


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> user-guide/forms-and-actions.rst:591: [broken] http://zf2-tutorial.localhost/: <urlopen error [Errno -2] Name or service not known>
