### PR TITLE
Fix user-guide/database-and-models.rst broken link

### DIFF
--- a/docs/languages/en/user-guide/database-and-models.rst
+++ b/docs/languages/en/user-guide/database-and-models.rst
@@ -161,7 +161,7 @@ updates a row that already exists and ``deleteAlbum()`` removes the row
 completely. The code for each of these methods is, hopefully, self-explanatory.
 
 Using ServiceManager to configure the table gateway and inject into the AlbumTable
------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------
 
 In order to always use the same instance of our ``AlbumTable``, we will use the
 ``ServiceManager`` to define how to create one. This is most easily done in the
@@ -396,7 +396,7 @@ links.
     We always use the ``escapeHtml()`` view helper to help protect
     ourselves from Cross Site Scripting (XSS) vulnerabilities (see http://en.wikipedia.org/wiki/Cross-site_scripting).
 
-If you open http://zf2-tutorial.localhost/album you should see this:
+If you open ``http://zf2-tutorial.localhost/album`` you should see this:
 
 .. image:: ../images/user-guide.database-and-models.album-list.png
     :width: 940 px


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> user-guide/database-and-models.rst:399: [broken] http://zf2-tutorial.localhost/album: <urlopen error [Errno -2] Name or service not known>
