### PR TITLE
Fix tutorials/tutorial.navigation.rst broken link

### DIFF
--- a/docs/languages/en/tutorials/tutorial.navigation.rst
+++ b/docs/languages/en/tutorials/tutorial.navigation.rst
@@ -33,7 +33,7 @@ app, a home page, and an albums area.
     ),
 
 This change means that if you go to the home page of your application
-(http://zf2-tutorial.localhost/), you see the default skeleton
+(``http://zf2-tutorial.localhost/``), you see the default skeleton
 application introduction. Your list of albums is still available at the
 /album route.
 


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> tutorials/tutorial.navigation.rst:35: [broken] http://zf2-tutorial.localhost/: <urlopen error [Errno -2] Name or service not known>
