### PR TITLE
Fix tutorials/quickstart.create.model.rst broken link

### DIFF
--- a/docs/languages/en/tutorials/quickstart.create.model.rst
+++ b/docs/languages/en/tutorials/quickstart.create.model.rst
@@ -643,7 +643,7 @@ And, of course, we need a view script to go along with that. Edit
 
    **Checkpoint**
 
-   Now browse to "http://localhost/guestbook". You should see the following in your browser:
+   Now browse to ``http://localhost/guestbook``. You should see the following in your browser:
 
    .. image:: ../images/learning.quickstart.create-model.png
       :width: 525


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> tutorials/quickstart.create.model.rst:646: [broken] http://localhost/guestbook: <urlopen error [Errno 111] Connection refused>
