### PR TITLE
Fix tutorials/quickstart.create.layout.rst broken link

### DIFF
--- a/docs/languages/en/tutorials/quickstart.create.layout.rst
+++ b/docs/languages/en/tutorials/quickstart.create.layout.rst
@@ -174,7 +174,7 @@ support a single action, you can do so, and be assured it will be present in the
 
    **Checkpoint**
 
-   Now go to "http://localhost" and check out the source. You should see your XHTML header, head, title, and body
+   Now go to ``http://localhost`` and check out the source. You should see your XHTML header, head, title, and body
    sections.
 
 


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> tutorials/quickstart.create.layout.rst:177: [broken] http://localhost: <urlopen error [Errno 111] Connection refused>
