### PR TITLE
Fix tutorials/quickstart.create.form.rst broken link

### DIFF
--- a/docs/languages/en/tutorials/quickstart.create.form.rst
+++ b/docs/languages/en/tutorials/quickstart.create.form.rst
@@ -150,7 +150,7 @@ Of course, we also need to edit the view script; edit ``application/views/script
 
    **Checkpoint**
 
-   Now browse to "http://localhost/guestbook/sign". You should see the following in your browser:
+   Now browse to ``http://localhost/guestbook/sign``. You should see the following in your browser:
 
    .. image:: ../images/learning.quickstart.create-form.png
       :width: 421


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> tutorials/quickstart.create.form.rst:153: [broken] http://localhost/guestbook/sign: <urlopen error [Errno 111] Connection refused>
