### PR TITLE
Fix ref/project.structure.rst broken link

### DIFF
--- a/docs/languages/en/ref/project.structure.rst
+++ b/docs/languages/en/ref/project.structure.rst
@@ -273,4 +273,4 @@ create the appropriate rewrite rules.
 .. _`Service Layer`: http://www.martinfowler.com/eaaCatalog/serviceLayer.html
 .. _`Userland Naming Guide`: http://www.php.net/manual/en/userlandnaming.php
 .. _`Apache documentation`: http://httpd.apache.org/docs/
-.. _`Blueprint for PHP Applications: Bootstrapping`: http://devzone.zend.com/a/70
+.. _`Blueprint for PHP Applications: Bootstrapping`: http://devzone.zend.com/400/blueprint-for-php-applications_bootstrapping-part-1/


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> ref/project.structure.rst:230: [broken] http://devzone.zend.com/a/70: HTTP Error 404: Not Found
