### PR TITLE
Fix modules/zend.json.server.rst broken links

### DIFF
--- a/docs/languages/en/modules/zend.json.server.rst
+++ b/docs/languages/en/modules/zend.json.server.rst
@@ -1,7 +1,7 @@
 .. _zend.json.server:
 
 Zend\\Json\\Server - JSON-RPC server
-==================================
+====================================
 
 ``Zend\Json\Server`` is a `JSON-RPC`_ server implementation. It supports both the `JSON-RPC version 1
 specification`_ as well as the `version 2 specification`_; additionally, it provides a *PHP* implementation of the
@@ -458,8 +458,8 @@ Methods available in ``Zend\Json\Server\Smd`` include:
 
 .. _`JSON-RPC`: http://groups.google.com/group/json-rpc/
 .. _`JSON-RPC version 1 specification`: http://json-rpc.org/wiki/specification
-.. _`version 2 specification`: http://groups.google.com/group/json-rpc/web/json-rpc-1-2-proposal
-.. _`Service Mapping Description (SMD) specification`: http://groups.google.com/group/json-schema/web/service-mapping-description-proposal
+.. _`version 2 specification`: http://www.jsonrpc.org/specification
+.. _`Service Mapping Description (SMD) specification`: http://www.jsonrpc.org/specification
 .. _`SoapServer`: http://www.php.net/manual/en/class.soapserver.php
 .. _`the XML-RPC EPI project`: http://xmlrpc-epi.sourceforge.net/specs/rfc.fault_codes.php
-.. _`specification`: http://groups.google.com/group/json-schema/web/service-mapping-description-proposal
+.. _`specification`: http://www.jsonrpc.org/specification


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> modules/zend.json.server.rst:6: [broken] http://groups.google.com/group/json-rpc/web/json-rpc-1-2-proposal: HTTP Error 404: Not Found
> modules/zend.json.server.rst:6: [broken] http://groups.google.com/group/json-schema/web/service-mapping-description-proposal: HTTP Error 404: Not Found
> modules/zend.json.server.rst:328: [broken] http://groups.google.com/group/json-schema/web/service-mapping-description-proposal: HTTP Error 404: Not Found
