### PR TITLE
Fix modules/zend.i18n.view.helper.plural.rst broken links

### DIFF
--- a/docs/languages/en/modules/zend.i18n.view.helper.plural.rst
+++ b/docs/languages/en/modules/zend.i18n.view.helper.plural.rst
@@ -24,8 +24,8 @@ hence break current applications that may (or may not) want those new rules.
 That's why defining rules is now up to the developer. To help you with this process, here are some links with up-to-date
 plural rules for tons of languages:
 
-* [http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html)
-* [https://developer.mozilla.org/en-US/docs/Localization_and_Plurals](https://developer.mozilla.org/en-US/docs/Localization_and_Plurals)
+* http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
+* https://developer.mozilla.org/en-US/docs/Localization_and_Plurals
 
 .. _zend.i18n.view.helper.plural.usage:
 


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> modules/zend.i18n.view.helper.plural.rst:27: [broken] http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html: HTTP Error 404: Not Found
> modules/zend.i18n.view.helper.plural.rst:28: [broken] https://developer.mozilla.org/en-US/docs/Localization_and_Plurals](https://developer.mozilla.org/en-US/docs/Localization_and_Plurals: HTTP Error 404: NOT FOUND
