### PR TITLE
Fix fix/modules/zend.progress-bar.rst broken link

### DIFF
--- a/docs/languages/en/modules/zend.progress-bar.adapter.js-push.rst
+++ b/docs/languages/en/modules/zend.progress-bar.adapter.js-push.rst
@@ -98,8 +98,6 @@ Dojo, jQuery etc. For example, there are:
 
 - MooTools: `http://davidwalsh.name/dw-content/progress-bar.php`_
 
-- Prototype: `http://livepipe.net/control/progressbar`_
-
 .. note::
 
    **Interval of updates**
@@ -113,4 +111,3 @@ Dojo, jQuery etc. For example, there are:
 .. _`http://dojotoolkit.org/reference-guide/dijit/ProgressBar.html`: http://dojotoolkit.org/reference-guide/dijit/ProgressBar.html
 .. _`http://t.wits.sg/2008/06/20/jquery-progress-bar-11/`: http://t.wits.sg/2008/06/20/jquery-progress-bar-11/
 .. _`http://davidwalsh.name/dw-content/progress-bar.php`: http://davidwalsh.name/dw-content/progress-bar.php
-.. _`http://livepipe.net/control/progressbar`: http://livepipe.net/control/progressbar


### PR DESCRIPTION
Fix broken links as seen in `make linkcheck` output:

> modules/zend.progress-bar.rst:101: [broken] http://livepipe.net/control/progressbar: <urlopen error timed out>
> modules/zend.progress-bar.adapter.js-push.rst:101: [broken] http://livepipe.net/control/progressbar: <urlopen error timed out>

Also, LivePipe has been deprecated and is no longer maintained.
