### PR TITLE
Fix name of the custom parmeters options for callback filter

### DIFF
--- a/docs/languages/en/modules/zend.filter.callback.rst
+++ b/docs/languages/en/modules/zend.filter.callback.rst
@@ -14,7 +14,7 @@ The following options are supported for ``Zend\Filter\Callback``:
 
 - **callback**: This sets the callback which should be used.
 
-- **options**: This property sets the options which are used when the callback is processed.
+- **callback_params**: This property sets the options which are used when the callback is processed.
 
 .. _zend.filter.set.callback.basic:
 


### PR DESCRIPTION
For the Callback filter, the name of the option that can be used to define parameters to pass to the callback is not '"options". It's "callback_params"
