### PR TITLE
Zend\Http\Header\HeaderInterface docblock seems incorrect

### DIFF
--- a/docs/languages/en/modules/zend.http.headers.rst
+++ b/docs/languages/en/modules/zend.http.headers.rst
@@ -294,7 +294,7 @@ Zend\\Http\\Header\\HeaderInterface Methods
 
    Cast to string as a well formed HTTP header line
 
-   Returns in form of "NAME: VALUE\\r\\n"
+   Returns in form of "NAME: VALUE"
 
    Returns string
 


### PR DESCRIPTION
The current version of [modules/zend.http.headers.rst](https://github.com/zendframework/zf2-documentation/blob/75712afcc92a0e9042eb9810671c9cfc455717d2/docs/languages/en/modules/zend.http.headers.rst#zendhttpheaderheaderinterface-methods) documents the `Zend\Http\Header\HeaderInterface`'s `toString()` as returning the header line 

> in the form of "NAME: VALUE\r\n"

This seems to be inconsistent with the actual return values of the `Zend\Http\Header\*` classes. Which one of these is incorrect? Should `toString()` return the headers with a CR and NL at the end of them (as per the spec) or should these docs be updated?
