### PR TITLE
Fix modules/zend.event-manager.event-manager.rst

### DIFF
--- a/docs/languages/en/modules/zend.event-manager.event-manager.rst
+++ b/docs/languages/en/modules/zend.event-manager.event-manager.rst
@@ -430,11 +430,13 @@ You will then pull that value back into your method.
        if (!$values) {
            return;
        }
+
        if (!isset($values['date'])) {
            $values['date'] = new \DateTime('now');
-           return;
+       } else {
+           $values['date'] = new \Datetime($values['date']);
        }
-       $values['date'] = new \Datetime($values['date']);
+       
        $e->setParam('values', $values);
    });
 


### PR DESCRIPTION
Changed the example where "prepareArgs()" is used. In the old example the passed params will be untouched in the method. This is fixed by using $e->setParam()
