### PR TITLE
Unit Testing Code Snippet

### DIFF
--- a/docs/languages/en/tutorials/unittesting.rst
+++ b/docs/languages/en/tutorials/unittesting.rst
@@ -465,6 +465,15 @@ Running ``phpunit`` gives us the following output:
 Testing the ``editAction`` and ``deleteAction`` methods can be easily done in a manner similar
 as shown for the ``addAction``.
 
+When testing the editAction you will also need to mock out the ``getAlbum`` method:
+    
+.. code-block:: php
+
+    $albumTableMock->expects($this->once())
+        ->method('getAlbum')
+        ->will($this->returnValue(new \Album\Model\Album()));
+
+
 .. _testing-model-entities:
 
 Testing model entities


### PR DESCRIPTION
I have added a sentence and snippet of code to inform the user that they will need to mock out the getAlbum() method of AlbumTable as you get the following error otherwise: (may help someone)

1) AlbumTest\Controller\AlbumControllerTest::testEditActionRedirectsAfterValidPost
Zend\Form\Exception\InvalidArgumentException: Zend\Form\Fieldset::setObject expects an object argument; received ""
