### PR TITLE
Mistaken statements

### DIFF
--- a/docs/languages/en/modules/zend.i18n.validator.alnum.rst
+++ b/docs/languages/en/modules/zend.i18n.validator.alnum.rst
@@ -59,13 +59,6 @@ an instance of the validator, or afterwards by using ``setAllowWhiteSpace()``. T
 Using different languages
 -------------------------
 
-When using ``Zend\I18n\Validator\Alnum`` then the language which the user sets within his browser will be used to set
-the allowed characters. This means when your user sets **de** for german then he can also enter characters like
-**ä**, **ö** and **ü** additionally to the characters from the english alphabet.
-
-Which characters are allowed depends completely on the used language as every language defines it's own set of
-characters.
-
 There are actually 3 languages which are not accepted in their own script. These languages are **korean**,
 **japanese** and **chinese** because this languages are using an alphabet where a single character is build by
 using multiple characters.


### PR DESCRIPTION
Seems like "the language which the user sets within his browser will be used to set the allowed characters ..." is not correct, because there is no Locale::acceptFromHttp() in AbstractLocale.

As well as "Which characters are allowed depends completely on the used language as every language defines it’s own set of characters.", because Zend\I18n\Filter\AbstractLocale use \p{L}.
