### PR TITLE
Example for File PRG used prg instead of fileprg

### DIFF
--- a/docs/languages/en/modules/zend.mvc.plugins.rst
+++ b/docs/languages/en/modules/zend.mvc.plugins.rst
@@ -499,7 +499,7 @@ This plugin can be invoked with three arguments:
    );
 
    // Pass in the route/url you want to redirect to after the POST
-   $prg = $this->prg($myForm, '/user/profile-pic', true);
+   $prg = $this->fileprg($myForm, '/user/profile-pic', true);
 
    if ($prg instanceof \Zend\Http\PhpEnvironment\Response) {
        // Returned a response to redirect us


### PR DESCRIPTION
Typo in example for File PRG.
