### PR TITLE
[zendframework/zf2#4785] Add documentation note about CSRF naming

### DIFF
--- a/docs/languages/en/modules/zend.form.element.csrf.rst
+++ b/docs/languages/en/modules/zend.form.element.csrf.rst
@@ -44,6 +44,14 @@ You can change the options of the CSRF validator using the ``setCsrfValidatorOpt
     	)
     ));
 
+.. note::
+
+    If you are using more than one form on a page, and each contains its own CSRF element, you will
+    need to make sure that each form uniquely names its element; if you do not, it's possible for
+    the value of one to override the other within the server-side session storage, leading to the
+    inability to validate one or more of the forms on your page. We suggest prefixing the element
+    name with the form's name or function: "login_csrf", "registration_csrf", etc.
+
 .. _zend.form.element.csrf.methods:
 
 .. rubric:: Public Methods


### PR DESCRIPTION
CSRF elements need to be uniquely named on the same page when multiple forms
are present.

Addresses zendframework/zf2#4785
