### PR TITLE
Update zend.mail.file.options.rst

### DIFF
--- a/docs/languages/en/modules/zend.mail.file.options.rst
+++ b/docs/languages/en/modules/zend.mail.file.options.rst
@@ -65,7 +65,7 @@ getters are provided.
 
 .. _zend.mail.file-options.methods.set-path:
 
-**__construct**
+**setPath**
    ``setPath(string $path)``
 
    Set the path under which mail files will be written.


### PR DESCRIPTION
Misleading "__construct" at the beginning of the doc spec. Changed to "setPath".
