### PR TITLE
Fixes wrong method name in Zend\Dom\Query

### DIFF
--- a/docs/languages/en/modules/zend.dom.query.rst
+++ b/docs/languages/en/modules/zend.dom.query.rst
@@ -18,7 +18,7 @@ Theory of Operation
 -------------------
 
 To use ``Zend\Dom\Query``, you instantiate a ``Zend\Dom\Query`` object, optionally passing a document to query (a
-string). Once you have a document, you can use either the ``query()`` or ``queryXpath()`` methods; each method will
+string). Once you have a document, you can use either the ``execute()`` or ``queryXpath()`` methods; each method will
 return a ``Zend\Dom\NodeList`` object with any matching nodes.
 
 The primary difference between ``Zend\Dom\Query`` and using `DOMDocument`_ + `DOMXPath`_ is the ability to select


### PR DESCRIPTION
http://framework.zend.com/apidoc/2.2/classes/Zend.Dom.Query.html#execute
