### PR TITLE
Use dev stability for the create-project command.

### DIFF
--- a/docs/languages/en/user-guide/skeleton-application.rst
+++ b/docs/languages/en/user-guide/skeleton-application.rst
@@ -11,7 +11,7 @@ to create a new project from scratch with Zend Framework:
 .. code-block:: bash
    :linenos:
 
-    php composer.phar create-project --repository-url="https://packages.zendframework.com" zendframework/skeleton-application path/to/install
+    php composer.phar create-project --repository-url="https://packages.zendframework.com" -s dev zendframework/skeleton-application path/to/install
     php composer.phar update
 
 .. note::


### PR DESCRIPTION
Without specifying the stability option, it defaults to stable, which is not available, giving the error `Could not find package zendframework/skeleton-application with stability stable.`.  For novices, this would be a source of confusion.
