### PR TITLE
Add base64 encoding to message attachment example

### DIFF
--- a/docs/languages/en/modules/zend.mail.attachments.rst
+++ b/docs/languages/en/modules/zend.mail.attachments.rst
@@ -27,6 +27,8 @@ Using Zend\\Mime\\Part
    $attachment->type = 'image/jpg';
    $attachment->filename = 'image-file-name.jpg';
    $attachment->disposition = Mime\Mime::DISPOSITION_ATTACHMENT;
+   // Setting the encoding is recommended for binary data
+   $attachment->encoding = Mime\Mime::ENCODING_BASE64; 
    
    // then add them to a MIME message
    $mimeMessage = new Mime\Message();


### PR DESCRIPTION
Following the example may at times result in broken or degraded images due to sending binary data over an ascii transport mechanism. Setting the encoding to base64 fixes this, so we should include this in the example.
