### PR TITLE
Update skeleton-application.rst

### DIFF
--- a/docs/languages/en/user-guide/skeleton-application.rst
+++ b/docs/languages/en/user-guide/skeleton-application.rst
@@ -12,6 +12,7 @@ to create a new project from scratch with Zend Framework:
    :linenos:
 
     php composer.phar create-project --stability="dev" repository-url="https://packages.zendframework.com" zendframework/skeleton-application path/to/install
+    cd path/to/install
     php composer.phar update
 
 .. note::


### PR DESCRIPTION
In addition to the missing --stability="dev" option (or -sdev) for composer, I added a step to the install commands.  One must execute the composer update command from _within_ the installation directory.

I'm surprised that so many people have commented about the stability option on the page, yet it hasn't been corrected by now.
