### PR TITLE
fix --repository-url param

### DIFF
--- a/docs/languages/en/user-guide/skeleton-application.rst
+++ b/docs/languages/en/user-guide/skeleton-application.rst
@@ -11,7 +11,7 @@ to create a new project from scratch with Zend Framework:
 .. code-block:: bash
    :linenos:
 
-    php composer.phar create-project --stability="dev" repository-url="https://packages.zendframework.com" zendframework/skeleton-application path/to/install
+    php composer.phar create-project --stability="dev" --repository-url="https://packages.zendframework.com" zendframework/skeleton-application path/to/install
     php composer.phar update
 
 .. note::


### PR DESCRIPTION
The copy&paste example was missing the dashes for the repository-url parameter
