### PR TITLE
Update zend.mail.file.options.rst

### DIFF
--- a/docs/languages/en/modules/zend.mail.file.options.rst
+++ b/docs/languages/en/modules/zend.mail.file.options.rst
@@ -60,7 +60,7 @@ Available Methods
 -----------------
 
 ``Zend\Mail\Transport\FileOptions`` extends ``Zend\Stdlib\Options``, and inherits all functionality from that
-class; this includes ``ArrayAccess`` and property overloading. Additionally, the following explicit setters and
+class; this includes property overloading. Additionally, the following explicit setters and
 getters are provided.
 
 .. _zend.mail.file-options.methods.set-path:


### PR DESCRIPTION
Zend\Stdlib\AbstractOptions does not implement ArrayAccess
