### PR TITLE
Fixed bug in session manager code example

### DIFF
--- a/docs/languages/en/modules/zend.session.manager.rst
+++ b/docs/languages/en/modules/zend.session.manager.rst
@@ -15,7 +15,7 @@ Initializing the Session Manager
 --------------------------------
 
 Generally speaking you will always want to initialize the session manager and ensure that you had initialized it
-on your end; this puts in place a simple solution to prevent against session fixation.  Generally you will 
+on your end; this puts in place a simple solution to prevent against session fixation.  Generally you will
 setup configuration and then inside of your Application module bootstrap the session manager.
 
 Additionally you will likely want to supply validators to prevent against session hijacking.
@@ -45,7 +45,7 @@ The following illustrates how you might utilize the above configuration to creat
 
 .. code-block:: php
    :linenos:
-   
+
    use Zend\Session\SessionManager;
    use Zend\Session\Container;
 
@@ -54,14 +54,13 @@ The following illustrates how you might utilize the above configuration to creat
        public function onBootstrap($e)
        {
            $eventManager        = $e->getApplication()->getEventManager();
-           $serviceManager      = $e->getApplication()->getServiceManager();
            $moduleRouteListener = new ModuleRouteListener();
            $moduleRouteListener->attach($eventManager);
            $this->bootstrapSession($e);
        }
 
        public function bootstrapSession($e)
-       {   
+       {
            $session = $e->getApplication()
                         ->getServiceManager()
                         ->get('Zend\Session\SessionManager');
@@ -69,10 +68,40 @@ The following illustrates how you might utilize the above configuration to creat
 
            $container = new Container('initialized');
            if (!isset($container->init)) {
-                $session->regenerateId(true);
-                $container->init = 1;
+               $serviceManager = $e->getApplication()->getServiceManager();
+               $request        = $serviceManager->get('Request');
+
+               $session->regenerateId(true);
+               $container->init          = 1;
+               $container->remoteAddr    = $request->getServer()->get('REMOTE_ADDR');
+               $container->httpUserAgent = $request->getServer()->get('HTTP_USER_AGENT');
+
+               $config = $serviceManager->get('Config');
+               if (!isset($config['session'])) {
+                   return;
+               }
+
+               $sessionConfig = $config['session'];
+               if (isset($sessionConfig['validators'])) {
+                   $chain   = $session->getValidatorChain();
+
+                   foreach ($sessionConfig['validators'] as $validator) {
+                       switch ($validator) {
+                           case 'Zend\Session\Validator\HttpUserAgent':
+                               $validator = new $validator($container->httpUserAgent);
+                               break;
+                           case 'Zend\Session\Validator\RemoteAddr':
+                               $validator  = new $validator($container->remoteAddr);
+                               break;
+                           default:
+                               $validator = new $validator();
+                       }
+
+                       $chain->attach('session.validate', array($validator, 'isValid'));
+                   }
+               }
            }
-       }   
+       }
 
        public function getServiceConfig()
        {
@@ -104,15 +133,6 @@ The following illustrates how you might utilize the above configuration to creat
                            }
 
                            $sessionManager = new SessionManager($sessionConfig, $sessionStorage, $sessionSaveHandler);
-
-                           if (isset($session['validators'])) {
-                               $chain = $sessionManager->getValidatorChain();
-                               foreach ($session['validators'] as $validator) {
-                                   $validator = new $validator();
-                                   $chain->attach('session.validate', array($validator, 'isValid'));
-
-                               }
-                           }
                        } else {
                            $sessionManager = new SessionManager();
                        }


### PR DESCRIPTION
This PR fixes issue #1341.

The validators always returned true, because there was no reference data provided to the validators via the constructor. Therefore the validators used the default value (`$_SERVER['HTTP_USER_AGENT']`), see: [`Zend\Session\Validator\HttpUserAgent::__construct`](https://github.com/zendframework/zf2/blob/master/library/Zend/Session/Validator/HttpUserAgent.php#L27-L35).

When [`Zend\Session\Validator\HttpUserAgent::isValid()`](https://github.com/zendframework/zf2/blob/master/library/Zend/Session/Validator/HttpUserAgent.php#L43-L50) is called it compares the value with `$_SERVER['HTTP_USER_AGENT']`, see: [Zend\Session\Validator\HttpUserAgent::__construct](https://github.com/zendframework/zf2/blob/master/library/Zend/Session/Validator/HttpUserAgent.php#L27-L34), and thus always returns `true`.

This PR fixes the code example to make it work as it should. It now throws an exception when the user agent is changed.

> Zend\Session\Exception\RuntimeException: Session validation failed in ...\vendor\zf2\library\Zend\Session\SessionManager.php on line 111

The same applies for `Zend\Session\Validator\RemoteAddr` in that same example.
