### PR TITLE
Zend\Di Definition: changed class name Configuration to Config

### DIFF
--- a/docs/languages/en/modules/zend.di.definitions.rst
+++ b/docs/languages/en/modules/zend.di.definitions.rst
@@ -125,7 +125,7 @@ an application, the following code will suffice:
            new Definition\ArrayDefinition(include __DIR__ . '/path/to/data/di/My_OtherClasses-definition.php'),
            $runtime = new Definition\RuntimeDefinition(),
        ));
-       $di = new Di($definitionList, null, new Configuration($this->config->di));
+       $di = new Di($definitionList, null, new Config($this->config->di));
        $di->instanceManager()->addTypePreference('Zend\Di\LocatorInterface', $di);
        $app->setLocator($di);
    }


### PR DESCRIPTION
The [first comment](http://framework.zend.com/manual/2.3/en/modules/zend.di.definitions.html#comment-647535090) mentions 2 bugs in the documentation:

> I have found two bugs in the documentation. At first, 'new Configuration' should be replaced with 'new Config' and the second thing is that there is no method 'setLocator' in the stable version of ZF2.

This PR fixes the first bug and changes `Configuration` into `Config`.

I can confirm the second bug where `Zend\Mvc\Application::setLocator` does not exist, but I'm not sure what it should be:

``` php
$app->setLocator($di);
```
