### PR TITLE
Update zend.validator.messages.rst

### DIFF
--- a/docs/languages/en/modules/zend.validator.messages.rst
+++ b/docs/languages/en/modules/zend.validator.messages.rst
@@ -79,7 +79,7 @@ So to translate all validation messages to German for example, all you have to d
 
    **Supported languages**
 
-   This feature is very young, so the amount of supported languages may not be complete. New languages will be
+   The amount of supported languages may not be complete. New languages will be
    added with each release. Additionally feel free to use the existing resource files to make your own
    translations.
 


### PR DESCRIPTION
The pre-translated validation messages feature is no longer "very young".
