### PR TITLE
Correct album route in user guide

### DIFF
--- a/docs/languages/en/user-guide/routing-and-controllers.rst
+++ b/docs/languages/en/user-guide/routing-and-controllers.rst
@@ -65,7 +65,7 @@ actions. This is the updated module config file with the new code highlighted.
                 'album' => array(
                     'type'    => 'segment',
                     'options' => array(
-                        'route'    => '/album[/][:action][/:id]',
+                        'route'    => '/album[/:action][/:id]',
                         'constraints' => array(
                             'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
                             'id'     => '[0-9]+',


### PR DESCRIPTION
Below of this code, the text are explaining that we have a `"/album[/:action][/:id]"` route, but the code was saying another thing.
