### PR TITLE
Fix IIS name in installation docs

### DIFF
--- a/docs/languages/en/ref/installation.rst
+++ b/docs/languages/en/ref/installation.rst
@@ -150,8 +150,8 @@ most use cases:
 
 .. _installation.iis:
 
-Microsoft Internet Information Server
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Microsoft Internet Information Serverices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As of version 7.0, *IIS* ships with a standard rewrite engine. You may use the following configuration to
 create the appropriate rewrite rules.


### PR DESCRIPTION
The real IIS's name is "Internet Information Services" because it's notjust a HTTP Server like Apache.
More information: http://es.wikipedia.org/wiki/Internet_Information_Services
