### PR TITLE
Failing tests due to missing id field + missing "/" in redirect URL

### DIFF
--- a/docs/languages/en/tutorials/unittesting.rst
+++ b/docs/languages/en/tutorials/unittesting.rst
@@ -441,11 +441,12 @@ with some POST data. Testing this is surprisingly easy:
         $postData = array(
             'title'  => 'Led Zeppelin III',
             'artist' => 'Led Zeppelin',
+            'id'     => '',
         );
         $this->dispatch('/album/add', 'POST', $postData);
         $this->assertResponseStatusCode(302);
 
-        $this->assertRedirectTo('/album');
+        $this->assertRedirectTo('/album/');
     }
 
 Here we test that when we make a POST request against the ``/album/add`` URL, the


### PR DESCRIPTION
I followed your tutorials step by step, and the "id" field is required.
Thus the "add" route refused to "create" an album, because this "id" field was missing, resulting in a 200 response code.
In the mean time, PHPUnit complained because I was redirected to "/album/", and not "/album"
