### PR TITLE
Failed using composer's autoload file

### DIFF
--- a/docs/languages/en/tutorials/unittesting.rst
+++ b/docs/languages/en/tutorials/unittesting.rst
@@ -28,7 +28,7 @@ installed. The version of PHPUnit used should be 3.7.*
 .. _setting-up-phpunit-to-use-composer-s-autoload-php:
 
 Setting up phpunit to use composer's autoload.php
-------------------------------
+-------------------------------------------------
 
 If you used composer to generate an autoload.php file for you,
 as seen in http://framework.zend.com/manual/2.3/en/user-guide/modules.html#autoloading-files => note,

--- a/docs/languages/en/tutorials/unittesting.rst
+++ b/docs/languages/en/tutorials/unittesting.rst
@@ -25,6 +25,25 @@ As the Zend Framework 2 API uses `PHPUnit <http://phpunit.de/>`_, so
 will this tutorial. This tutorial assumes that you already have PHPUnit
 installed. The version of PHPUnit used should be 3.7.*
 
+.. _setting-up-phpunit-to-use-composer-s-autoload-php:
+
+Setting up phpunit to use composer's autoload.php
+------------------------------
+
+If you used composer to generate an autoload.php file for you,
+as seen in http://framework.zend.com/manual/2.3/en/user-guide/modules.html#autoloading-files => note,
+then you need to use a phpunit binary installed by composer.
+Add to composer.json:
+
+    .. code-block:: javascript
+       :linenos:
+
+        "require-dev": {
+            "phpunit/phpunit": "*"
+        },
+
+Then run ``php composer.phar update`` to update the composer autoloading files.
+
 .. _setting-up-the-tests-directory:
 
 Setting up the tests directory


### PR DESCRIPTION
I tried to launch my Mint's version of PHPUnit, but it couldn't load my project's autoload files.

This resulted in the following error : + 1 :
```
[05-Dec-2014 15:56:58 Europe/Paris] PHP Fatal error:  Class 'Album\Controller\AlbumController' not found in /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/ServiceManager/AbstractPluginManager.php on line 170
[05-Dec-2014 15:56:58 Europe/Paris] PHP Stack trace:
[05-Dec-2014 15:56:58 Europe/Paris] PHP   1. {main}() /usr/bin/phpunit:0
[05-Dec-2014 15:56:58 Europe/Paris] PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:46
[05-Dec-2014 15:56:58 Europe/Paris] PHP   3. PHPUnit_TextUI_Command->run() /usr/share/php/PHPUnit/TextUI/Command.php:129
[05-Dec-2014 15:56:58 Europe/Paris] PHP   4. PHPUnit_TextUI_TestRunner->doRun() /usr/share/php/PHPUnit/TextUI/Command.php:176
[05-Dec-2014 15:56:58 Europe/Paris] PHP   5. PHPUnit_Framework_TestSuite->run() /usr/share/php/PHPUnit/TextUI/TestRunner.php:349
[05-Dec-2014 15:56:58 Europe/Paris] PHP   6. PHPUnit_Framework_TestSuite->run() /usr/share/php/PHPUnit/Framework/TestSuite.php:705
[05-Dec-2014 15:56:58 Europe/Paris] PHP   7. PHPUnit_Framework_TestSuite->runTest() /usr/share/php/PHPUnit/Framework/TestSuite.php:745
[05-Dec-2014 15:56:58 Europe/Paris] PHP   8. PHPUnit_Framework_TestCase->run() /usr/share/php/PHPUnit/Framework/TestSuite.php:775
[05-Dec-2014 15:56:58 Europe/Paris] PHP   9. PHPUnit_Framework_TestResult->run() /usr/share/php/PHPUnit/Framework/TestCase.php:783
[05-Dec-2014 15:56:58 Europe/Paris] PHP  10. PHPUnit_Framework_TestCase->runBare() /usr/share/php/PHPUnit/Framework/TestResult.php:648
[05-Dec-2014 15:56:58 Europe/Paris] PHP  11. PHPUnit_Framework_TestCase->runTest() /usr/share/php/PHPUnit/Framework/TestCase.php:838
[05-Dec-2014 15:56:58 Europe/Paris] PHP  12. ReflectionMethod->invokeArgs() /usr/share/php/PHPUnit/Framework/TestCase.php:983
[05-Dec-2014 15:56:58 Europe/Paris] PHP  13. AlbumTest\Controller\AlbumControllerTest->testIndexActionCanBeAccessed() /usr/share/php/PHPUnit/Framework/TestCase.php:983
[05-Dec-2014 15:56:58 Europe/Paris] PHP  14. Zend\Test\PHPUnit\Controller\AbstractControllerTestCase->dispatch() /home/andy/workspace/zf2/module/Album/test/AlbumTest/Controller/AlbumControllerTest.php:28
[05-Dec-2014 15:56:58 Europe/Paris] PHP  15. Zend\Mvc\Application->run() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php:288
[05-Dec-2014 15:56:58 Europe/Paris] PHP  16. Zend\EventManager\EventManager->trigger() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/Mvc/Application.php:313
[05-Dec-2014 15:56:58 Europe/Paris] PHP  17. Zend\EventManager\EventManager->triggerListeners() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:207
[05-Dec-2014 15:56:58 Europe/Paris] PHP  18. call_user_func() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:468
[05-Dec-2014 15:56:58 Europe/Paris] PHP  19. Zend\Mvc\DispatchListener->onDispatch() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:468
[05-Dec-2014 15:56:58 Europe/Paris] PHP  20. Zend\Mvc\Controller\ControllerManager->get() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/Mvc/DispatchListener.php:97
[05-Dec-2014 15:56:58 Europe/Paris] PHP  21. Zend\ServiceManager\AbstractPluginManager->get() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/Mvc/Controller/ControllerManager.php:137
[05-Dec-2014 15:56:58 Europe/Paris] PHP  22. Zend\ServiceManager\ServiceManager->get() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/ServiceManager/AbstractPluginManager.php:103
[05-Dec-2014 15:56:58 Europe/Paris] PHP  23. Zend\ServiceManager\ServiceManager->create() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/ServiceManager/ServiceManager.php:504
[05-Dec-2014 15:56:58 Europe/Paris] PHP  24. Zend\ServiceManager\ServiceManager->doCreate() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/ServiceManager/ServiceManager.php:572
[05-Dec-2014 15:56:58 Europe/Paris] PHP  25. Zend\ServiceManager\AbstractPluginManager->createFromInvokable() /home/andy/workspace/zf2/vendor/zendframework/zendframework/library/Zend/ServiceManager/ServiceManager.php:616
[05-Dec-2014 16:04:11 Europe/Paris] PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'Cannot create phar '/home/andy/workspace/zf2/vendor/bin/phpunit', file extension (or combination) not recognised or the directory does not exist' in /tmp/ide-phpunit.php:162
```

The only way I found, in order to make PHPUnit use Composer's auto-generated `autoload.php` file, without rewriting the whole Module.php file, was to add phpunit to composer's require-dev dependencies, then use this specific phpunit version to run my tests.