### PR TITLE
bugfix in using HEREDOC syntax

### DIFF
--- a/docs/languages/en/modules/zend.http.response.rst
+++ b/docs/languages/en/modules/zend.http.response.rst
@@ -69,7 +69,8 @@ completely empty object to start with, by simply instantiating the ``Zend\Http\R
        Hello World
    </body>
    </html>
-   EOS);
+   EOS
+   );
 
 .. _zend.http.response.options:
 


### PR DESCRIPTION
you cannot write anything else than the string identifier, when you want to end it.
As seen in this exemple :
andy@plaxton-mint ~/workspace/zf2/public (master %) $ php -a
Interactive mode enabled

php > $a = (<<<A
<<< > zeiuzeyf zeiuzef
<<< > zerferf
<<< > erfefer
<<< > freferf
<<< > erfrefr
<<< > A);
<<< > A
php ( );
php > echo $a;
zeiuzeyf zeiuzef
zerferf
erfefer
freferf
erfrefr
A);php >

see http://php.net/manual/fr/language.types.string.php#language.types.string.syntax.heredoc for more details
