### PR TITLE
Fix links for the IsFloat and IsInt validators

### DIFF
--- a/docs/src/modules/zend.validator.set.rst
+++ b/docs/src/modules/zend.validator.set.rst
@@ -29,8 +29,8 @@ Included Validators
 - :ref:`InArray <zend.validator.in_array>`
 - :ref:`Ip <zend.validator.ip>`
 - :ref:`Isbn <zend.validator.isbn>`
-- :ref:`IsFloat <zend.i18n.validator.float`
-- :ref:`IsInt <zend.i18n.validator.int`
+- :ref:`IsFloat <zend.i18n.validator.float>`
+- :ref:`IsInt <zend.i18n.validator.set.int>`
 - :ref:`LessThan <zend.validator.lessthan>`
 - :ref:`NotEmpty <zend.validator.notempty>`
 - :ref:`PostCode <zend.validator.post_code>`


### PR DESCRIPTION
Currently the links are not displaying correctly and some of the rst code is showing on the page:
http://framework.zend.com/manual/current/en/modules/zend.validator.set.html