### PR TITLE
Update zend-db-sql-zend-stdlib-hydrator.rst

### DIFF
--- a/docs/src/in-depth-guide/zend-db-sql-zend-stdlib-hydrator.rst
+++ b/docs/src/in-depth-guide/zend-db-sql-zend-stdlib-hydrator.rst
@@ -119,7 +119,7 @@ will look like the following:
         ),
         'service_manager' => array(
             'factories' => array(
-                'Blog\Service\PostServiceInterface' => 'Blog\Service\Factory\PostServiceFactory',
+                'Blog\Service\PostServiceInterface' => 'Blog\Factory\PostServiceFactory',
                 'Zend\Db\Adapter\Adapter'           => 'Zend\Db\Adapter\AdapterServiceFactory'
             )
         ),


### PR DESCRIPTION
Replaced "Blog\Service\Factory\PostServiceFactory" by "Blog\Factory\PostServiceFactory" 
"Service\Factory" is a non-exsting path.