### PR TITLE
update unit tests tutorial Bootstrap::initAutoloader()

### DIFF
--- a/docs/src/tutorials/unittesting.rst
+++ b/docs/src/tutorials/unittesting.rst
@@ -159,29 +159,16 @@ And a file called ``Bootstrap.php``, also under ``zf2-tutorial/module/Album/test
         {
             $vendorPath = static::findParentPath('vendor');
 
-            $zf2Path = getenv('ZF2_PATH');
-            if (!$zf2Path) {
-                if (defined('ZF2_PATH')) {
-                    $zf2Path = ZF2_PATH;
-                } elseif (is_dir($vendorPath . '/ZF2/library')) {
-                    $zf2Path = $vendorPath . '/ZF2/library';
-                } elseif (is_dir($vendorPath . '/zendframework/zendframework/library')) {
-                    $zf2Path = $vendorPath . '/zendframework/zendframework/library';
-                }
+            if (file_exists($vendorPath.'/autoload.php')) {
+                include $vendorPath.'/autoload.php';
             }
 
-            if (!$zf2Path) {
+            if (! class_exists('Zend\Loader\AutoloaderFactory')) {
                 throw new RuntimeException(
-                    'Unable to load ZF2. Run `php composer.phar install` or'
-                    . ' define a ZF2_PATH environment variable.'
+                    'Unable to load ZF2. Run `php composer.phar install`'
                 );
             }
-            
-            if (file_exists($vendorPath . '/autoload.php')) {
-                include $vendorPath . '/autoload.php';
-            }
 
-            include $zf2Path . '/Zend/Loader/AutoloaderFactory.php';
             AutoloaderFactory::factory(array(
                 'Zend\Loader\StandardAutoloader' => array(
                     'autoregister_zf' => true,


### PR DESCRIPTION
to make works with zf ~2.5, but still will work for zf ~2.4.0