### PR TITLE
Update zend-form-zend-form-fieldset.rst

### DIFF
--- a/docs/src/in-depth-guide/zend-form-zend-form-fieldset.rst
+++ b/docs/src/in-depth-guide/zend-form-zend-form-fieldset.rst
@@ -634,7 +634,9 @@ As you can see the ``savePost()`` function has been added and needs to be implem
     <?php
     // Filename: /module/Blog/src/Blog/Service/PostService.php
     namespace Blog\Service;
-
+    
+    use Blog\Model\Post;
+    use Blog\Model\PostInterface;
     use Blog\Mapper\PostMapperInterface;
     
 


### PR DESCRIPTION
This update fixes an omission to the tutorial. Failure to include the following lines in ''/module/Blog/src/Blog/Service/PostService.php'' will result in
a Fatal Error:
> use Blog\Model\Post;
> use Blog\Model\PostInterface;