### PR TITLE
add `use` clause in code example

### DIFF
--- a/docs/src/in-depth-guide/zend-form-zend-form-fieldset.rst
+++ b/docs/src/in-depth-guide/zend-form-zend-form-fieldset.rst
@@ -636,7 +636,7 @@ As you can see the ``savePost()`` function has been added and needs to be implem
     namespace Blog\Service;
 
     use Blog\Mapper\PostMapperInterface;
-    
+    use Blog\Model\PostInterface;
 
     class PostService implements PostServiceInterface
     {


### PR DESCRIPTION
add the `use Blog\Model\PostInterface;` clause in the `PostService` class, do that `PostInterface` can have the correct namespace